### PR TITLE
Support password with special chars and test for url encoded URI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,21 +64,28 @@ jobs:
           sudo systemctl restart postgresql@${{ matrix.pg.to }}-main.service
           sudo systemctl restart postgresql
 
+          # Escape the quote because we are setting the password in PG
+          # String: jamesbond123@7!''3aaR
+          export PGPASSWORD='jamesbond123@7!'"'"''"'"'3aaR'
+
           sudo su - postgres -c "createuser -p 5432 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5432 -c "alter user jamesbond with encrypted password 'jamesbond';"
+          sudo -u postgres psql -p 5432 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           sudo su - postgres -c "createuser -p 5433 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5433 -c "alter user jamesbond with encrypted password 'jamesbond';"
+          sudo -u postgres psql -p 5433 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
-          PGPASSWORD="jamesbond" psql -h localhost -d postgres -U jamesbond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
-          PGPASSWORD="jamesbond" psql -h localhost -d postgres -U jamesbond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
+          # Remove the escaped quote since we are passing the pwd to psql
+          # String: jamesbond123@7!'3aaR
+          export PGPASSWORD='jamesbond123@7!'"'"'3aaR'
+          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
+          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
 
           sudo systemctl restart postgresql@${{ matrix.pg.from }}-main.service
           sudo systemctl restart postgresql@${{ matrix.pg.to }}-main.service
           sudo systemctl restart postgresql
 
-          PGPASSWORD="jamesbond" psql -h localhost -d postgres -U jamesbond -p 5432 -c 'show wal_level;'
-          PGPASSWORD="jamesbond" psql -h localhost -d postgres -U jamesbond -p 5433 -c 'show wal_level;'
+          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'show wal_level;'
+          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'show wal_level;'
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_USER: jamesbond
-      POSTGRES_PASSWORD: jamesbond
+      POSTGRES_PASSWORD: jamesbond123@7!'3aaR
       POSTGRES_DB: postgres
     command: >
       -c wal_level=logical
@@ -22,7 +22,7 @@ services:
       - "5433:5432"
     environment:
       POSTGRES_USER: jamesbond
-      POSTGRES_PASSWORD: jamesbond
+      POSTGRES_PASSWORD: jamesbond123@7!'3aaR
       POSTGRES_DB: postgres
     command: >
       -c wal_level=logical

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -171,7 +171,7 @@ module PgEasyReplicate
     end
 
     def create_user(conn_string:, group_name:)
-      password = connection_info(conn_string)[:user]
+      password = connection_info(conn_string)[:password].gsub("'") { "''" }
       sql = <<~SQL
         drop role if exists #{internal_user_name};
         create role #{internal_user_name} with password '#{password}' login superuser createdb createrole;

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -5,21 +5,23 @@ module DatabaseHelpers
     ENV["POSTGRES_SCHEMA"] || "pger_test"
   end
 
+  # We are use url encoded password below.
+  # Original password is jamesbond123@7!'3aaR
   def connection_url
-    "postgres://jamesbond:jamesbond@localhost:5432/postgres"
+    "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
   end
 
   def target_connection_url
-    "postgres://jamesbond:jamesbond@localhost:5433/postgres"
+    "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5433/postgres"
   end
 
   def docker_compose_target_connection_url
-    "postgres://jamesbond:jamesbond@target_db/postgres"
+    "postgres://jamesbond:jamesbond123%407%21%273aaR@target_db/postgres"
   end
 
   def docker_compose_source_connection_url
     return connection_url if ENV["GITHUB_WORKFLOW"] # if running in CI/github actions
-    "postgres://jamesbond:jamesbond@source_db/postgres"
+    "postgres://jamesbond:jamesbond123%407%21%273aaR@source_db/postgres"
   end
 
   def new_dummy_table_sql
@@ -144,9 +146,9 @@ module DatabaseHelpers
   def self.populate_env_vars
     ENV[
       "SOURCE_DB_URL"
-    ] = "postgres://jamesbond:jamesbond@localhost:5432/postgres"
+    ] = "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
     ENV[
       "TARGET_DB_URL"
-    ] = "postgres://jamesbond:jamesbond@localhost:5433/postgres"
+    ] = "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5433/postgres"
   end
 end

--- a/spec/pg_easy_replicate/query_spec.rb
+++ b/spec/pg_easy_replicate/query_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(PgEasyReplicate::Query) do
     before { setup_tables }
 
     let(:connection_url) do
-      "postgres://jamesbond:jamesbond@localhost:5432/postgres"
+      "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
     end
 
     it "runs the query successfully" do


### PR DESCRIPTION
Also supports `'` in password.

New unescaped password for CI: `jamesbond123@7!'3aaR`

Fixes: https://github.com/shayonj/pg_easy_replicate/issues/16