### PR TITLE
Support AWS and GCP special user scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Battle tested in production at [Tines](https://www.tines.com/) 🚀
 - [Replicating all tables with a single group](#replicating-all-tables-with-a-single-group)
   - [Config check](#config-check)
   - [Bootstrap](#bootstrap)
+  - [Bootstrap and Config Check with special user role (AWS/GCP/Custom)](#bootstrap-and-config-check-with-special-user-role--aws-gcp-custom-)
+    - [Config Check](#config-check)
+    - [Bootstrap](#bootstrap-1)
   - [Start sync](#start-sync)
   - [Stats](#stats)
   - [Performing switchover](#performing-switchover)
@@ -22,6 +25,7 @@ Battle tested in production at [Tines](https://www.tines.com/) 🚀
 - [Switchover strategies with minimal downtime](#switchover-strategies-with-minimal-downtime)
   - [Rolling restart strategy](#rolling-restart-strategy)
   - [DNS Failover strategy](#dns-failover-strategy)
+- [Contributing](#contributing)
 
 ## Installation
 
@@ -51,7 +55,7 @@ https://hub.docker.com/r/shayonj/pg_easy_replicate
 
 - PostgreSQL 10 and later
 - Ruby 2.7 and later
-- Database user should have permissions for `SUPERUSER`
+- Database user should have permissions for `SUPERUSER` or pass in the special user role that has the privileges to create role, schema, publication and subscription on both databases. More on `--special-user-role` section below.
 - Both databases should have the same schema
 
 ## Limits
@@ -111,6 +115,31 @@ Every sync will need to be bootstrapped before you can set up the sync between t
 
 ```bash
 $ pg_easy_replicate bootstrap --group-name database-cluster-1
+
+{"name":"pg_easy_replicate","hostname":"PKHXQVK6DW","pid":21485,"level":30,"time":"2023-06-19T15:51:11.015-04:00","v":0,"msg":"Setting up schema","version":"0.1.0"}
+...
+```
+
+### Bootstrap and Config Check with special user role (AWS/GCP/Custom)
+
+If you don't want your primary login user to have `superuser` privileges or you are on AWS or GCP, you will need to pass in the special user role that has the privileges to create role, schema, publication and subscription. This is required so `pg_easy_replicate` can create a dedicated user for replication which is granted the respective special user role to carry out its functionalities.
+
+For AWS the special user role is `rds_superuser`, and for GCP it is `cloudsqlsuperuser`. Please refer to docs for the most up to date information.
+
+**Note**: The user in the connection url must be part of the special user role being supplied.
+
+#### Config Check
+
+```bash
+$ pg_easy_replicate config_check --special-user-role="rds_superuser"
+
+✅ Config is looking good.
+```
+
+#### Bootstrap
+
+```bash
+$ pg_easy_replicate bootstrap --group-name database-cluster-1 --special-user-role="rds_superuser"
 
 {"name":"pg_easy_replicate","hostname":"PKHXQVK6DW","pid":21485,"level":30,"time":"2023-06-19T15:51:11.015-04:00","v":0,"msg":"Setting up schema","version":"0.1.0"}
 ...

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -8,8 +8,14 @@ module PgEasyReplicate
 
     desc "config_check",
          "Prints if source and target database have the required config"
-    def config_check
-      PgEasyReplicate.assert_config
+    method_option :special_user_role,
+                  aliases: "-s",
+                  desc:
+                    "Name of the role that has superuser permissions. Usually useful for AWS (rds_superuser) or GCP (cloudsqlsuperuser)."
+    def config_check(options)
+      PgEasyReplicate.assert_config(
+        special_user_role: options[:special_user_role],
+      )
 
       puts "✅ Config is looking good."
     end
@@ -18,6 +24,10 @@ module PgEasyReplicate
                   aliases: "-g",
                   required: true,
                   desc: "Name of the group to provision"
+    method_option :special_user_role,
+                  aliases: "-s",
+                  desc:
+                    "Name of the role that has superuser permissions. Usually useful with AWS (rds_superuser) or GCP (cloudsqlsuperuser)."
     desc "bootstrap",
          "Sets up temporary tables for information required during runtime"
     def bootstrap

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -60,6 +60,10 @@ module PgEasyReplicate
       connection_info(url)[:user]
     end
 
+    def db_name(url)
+      connection_info(url)[:dbname]
+    end
+
     def abort_with(msg)
       raise(msg) if test_env?
       abort(msg)

--- a/lib/pg_easy_replicate/stats.rb
+++ b/lib/pg_easy_replicate/stats.rb
@@ -13,7 +13,6 @@ module PgEasyReplicate
 
     class << self
       def object(group_name)
-        PgEasyReplicate.assert_config
         stats = replication_stats(group_name)
         group = Group.find(group_name)
         {

--- a/spec/pg_easy_replicate/query_spec.rb
+++ b/spec/pg_easy_replicate/query_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe(PgEasyReplicate::Query) do
   describe ".run" do
     before { setup_tables }
 
-    let(:connection_url) do
-      "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
-    end
-
     it "runs the query successfully" do
       result =
         described_class.run(


### PR DESCRIPTION
`CREATE SUBSCRIPTION` requires that the user is superuser, which is why we require the user for source and target url/con string to be `superuser`. However, AWS and GCP don't have a `superuser` role but expose dedicated roles that act as super user (`rds_superuser` and `cloudsqlsuperuser`) and can perform `create subscription`. 

This PR now supports passing such user role during `bootstrap` and `config_check`. We then accordingly ensure that the internal user we create for replication has been granted the passed in `special_user_role` accordingly. Its a little hard to write spec for since we still need grantee role to be superuser when creating subscription. IOW, hard to re-create the same scenario that AWS / GCP have created in their version of PostgreSQL and exposed custom roles like `rds_superuser` and `cloudsqlsuperuser`.

That said, in this PR we have also relaxed permissions during config check. If a `special_user_role` is passed, we just make sure that user on the source and target db is a member of the `special_user_role`. If `special_user_role` is not passed, we expect the user to be a `superuser`.

Some minor refactoring along the way. 


```bash
$ pg_easy_replicate config_check --special-user-role="rds_superuser"

✅ Config is looking good.
```

```bash
$ pg_easy_replicate bootstrap --group-name database-cluster-1 --special-user-role="rds_superuser"

{"name":"pg_easy_replicate","hostname":"PKHXQVK6DW","pid":21485,"level":30,"time":"2023-06-19T15:51:11.015-04:00","v":0,"msg":"Setting up schema","version":"0.1.0"}
...
```

Fixes: https://github.com/shayonj/pg_easy_replicate/issues/15