### PR TITLE
Introduce --copy-schema via pg_dump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,6 @@ FROM ruby:3.1.4
 
 ARG VERSION
 
+RUN apt-get update && apt-get install postgresql-client -y
+RUN pg_dump --version
 RUN gem install pg_easy_replicate -v $VERSION

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ https://hub.docker.com/r/shayonj/pg_easy_replicate
 - PostgreSQL 10 and later
 - Ruby 2.7 and later
 - Database user should have permissions for `SUPERUSER` or pass in the special user role that has the privileges to create role, schema, publication and subscription on both databases. More on `--special-user-role` section below.
-- Both databases should have the same schema
 
 ## Limits
 
@@ -117,7 +116,7 @@ $ pg_easy_replicate config_check
 Every sync will need to be bootstrapped before you can set up the sync between two databases. Bootstrap creates a new super user to perform the orchestration required during the rest of the process. It also creates some internal metadata tables for record keeping.
 
 ```bash
-$ pg_easy_replicate bootstrap --group-name database-cluster-1
+$ pg_easy_replicate bootstrap --group-name database-cluster-1 --copy-schema
 
 {"name":"pg_easy_replicate","hostname":"PKHXQVK6DW","pid":21485,"level":30,"time":"2023-06-19T15:51:11.015-04:00","v":0,"msg":"Setting up schema","version":"0.1.0"}
 ...
@@ -134,7 +133,7 @@ For AWS the special user role is `rds_superuser`, and for GCP it is `cloudsqlsup
 #### Config Check
 
 ```bash
-$ pg_easy_replicate config_check --special-user-role="rds_superuser"
+$ pg_easy_replicate config_check --special-user-role="rds_superuser" --copy-schema
 
 ✅ Config is looking good.
 ```
@@ -142,7 +141,7 @@ $ pg_easy_replicate config_check --special-user-role="rds_superuser"
 #### Bootstrap
 
 ```bash
-$ pg_easy_replicate bootstrap --group-name database-cluster-1 --special-user-role="rds_superuser"
+$ pg_easy_replicate bootstrap --group-name database-cluster-1 --special-user-role="rds_superuser" --copy-schema
 
 {"name":"pg_easy_replicate","hostname":"PKHXQVK6DW","pid":21485,"level":30,"time":"2023-06-19T15:51:11.015-04:00","v":0,"msg":"Setting up schema","version":"0.1.0"}
 ...
@@ -219,12 +218,12 @@ By default all tables are added for replication but you can create multiple grou
 
 ```bash
 
-$ pg_easy_replicate bootstrap --group-name database-cluster-1
+$ pg_easy_replicate bootstrap --group-name database-cluster-1 --copy-schema
 $ pg_easy_replicate start_sync --group-name database-cluster-1 --schema-name public --tables "users, posts, events"
 
 ...
 
-$ pg_easy_replicate bootstrap --group-name database-cluster-2
+$ pg_easy_replicate bootstrap --group-name database-cluster-2 --copy-schema
 $ pg_easy_replicate start_sync --group-name database-cluster-2 --schema-name public --tables "comments, views"
 
 ...

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -12,9 +12,14 @@ module PgEasyReplicate
                   aliases: "-s",
                   desc:
                     "Name of the role that has superuser permissions. Usually useful for AWS (rds_superuser) or GCP (cloudsqlsuperuser)."
+    method_option :copy_schema,
+                  aliases: "-c",
+                  boolean: true,
+                  desc: "Copy schema to the new database"
     def config_check
       PgEasyReplicate.assert_config(
         special_user_role: options[:special_user_role],
+        copy_schema: options[:copy_schema],
       )
 
       puts "✅ Config is looking good."
@@ -28,6 +33,10 @@ module PgEasyReplicate
                   aliases: "-s",
                   desc:
                     "Name of the role that has superuser permissions. Usually useful with AWS (rds_superuser) or GCP (cloudsqlsuperuser)."
+    method_option :copy_schema,
+                  aliases: "-c",
+                  boolean: true,
+                  desc: "Copy schema to the new database"
     desc "bootstrap",
          "Sets up temporary tables for information required during runtime"
     def bootstrap

--- a/scripts/e2e-bootstrap.sh
+++ b/scripts/e2e-bootstrap.sh
@@ -12,8 +12,4 @@ export PGPASSWORD='jamesbond123@7!'"'"'3aaR'
 
 pgbench --initialize -s 5 --foreign-keys --host localhost -U jamesbond -d postgres
 
-pg_dump --schema-only --host localhost -U jamesbond -d postgres >schema.sql
-cat schema.sql | psql --host localhost -U jamesbond -d postgres -p 5433
-rm schema.sql
-
-bundle exec bin/pg_easy_replicate config_check
+bundle exec bin/pg_easy_replicate config_check --copy-schema

--- a/scripts/e2e-start.sh
+++ b/scripts/e2e-start.sh
@@ -12,7 +12,7 @@ export PGPASSWORD='jamesbond123@7!'"'"''"'"'3aaR'
 
 # Bootstrap and cleanup
 echo "===== Performing Bootstrap and cleanup"
-bundle exec bin/pg_easy_replicate bootstrap -g cluster-1
+bundle exec bin/pg_easy_replicate bootstrap -g cluster-1 --copy-schema
 bundle exec bin/pg_easy_replicate start_sync -g cluster-1 -s public
 bundle exec bin/pg_easy_replicate stats -g cluster-1
 bundle exec bin/pg_easy_replicate switchover -g cluster-1

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -24,9 +24,9 @@ module DatabaseHelpers
     "postgres://#{user}:jamesbond123%407%21%273aaR@source_db/postgres"
   end
 
-  def setup_tables(user = "jamesbond")
+  def setup_tables(user = "jamesbond", setup_target_db: true)
     setup(connection_url(user), user)
-    setup(target_connection_url(user), user)
+    setup(target_connection_url(user), user) if setup_target_db
   end
 
   def setup_roles

--- a/spec/pg_easy_replicate/group_spec.rb
+++ b/spec/pg_easy_replicate/group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(PgEasyReplicate::Group) do
   describe ".setup" do
     before do
       PgEasyReplicate.bootstrap({ group_name: "cluster1" })
-      PgEasyReplicate.setup_schema
+      PgEasyReplicate.setup_internal_schema
     end
 
     after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   config.include(DatabaseHelpers)
   config.before(:suite) { DatabaseHelpers.populate_env_vars }
   config.after(:suite) do
-    PgEasyReplicate.drop_schema
+    PgEasyReplicate.drop_internal_schema
   rescue StandardError # rubocop:disable Lint/SuppressedException
   end
 end


### PR DESCRIPTION
By passing --copy_schema to boostrap, pg_easy_replicate will now automatically copy schema between the source and target database by via pg_dump. pg_dump should exist on the host machine (or container image, will be in the official image) in order for it to work

closes: https://github.com/shayonj/pg_easy_replicate/issues/4