### PR TITLE
Exclude views, temporary tables and foreign tables from #list_all_tables

### DIFF
--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -107,7 +107,11 @@ module PgEasyReplicate
         Query
           .run(
             query:
-              "SELECT table_name FROM information_schema.tables WHERE table_schema = '#{schema}' ORDER BY table_name",
+              "SELECT table_name
+               FROM information_schema.tables
+               WHERE table_schema = '#{schema}' AND
+                 table_type = 'BASE TABLE'
+               ORDER BY table_name",
             connection_url: conn_string,
           )
           .map(&:values)


### PR DESCRIPTION
Limit #list_all_tables to only return tables of type BASE TABLE.

This will exclude database views, foreign tables and temporary tables from the list, which cannot be replicated.