### PR TITLE
Add quote_identifier helper for SQL identifiers.

### DIFF
--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -43,6 +43,10 @@ module PgEasyReplicate
         .downcase
     end
 
+    def quote_identifier(sql_ident)
+      PG::Connection.quote_ident(sql_ident)
+    end
+
     def test_env?
       ENV.fetch("RACK_ENV", nil) == "test"
     end

--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -94,7 +94,8 @@ module PgEasyReplicate
           .map do |table_name|
             Query.run(
               query:
-                "ALTER PUBLICATION #{publication_name(group_name)} ADD TABLE \"#{table_name}\"",
+                "ALTER PUBLICATION #{quote_identifier(publication_name(group_name))}
+                        ADD TABLE #{quote_identifier(table_name)}",
               connection_url: conn_string,
               schema: schema,
             )
@@ -121,7 +122,7 @@ module PgEasyReplicate
           { publication_name: publication_name(group_name) },
         )
         Query.run(
-          query: "DROP PUBLICATION IF EXISTS #{publication_name(group_name)}",
+          query: "DROP PUBLICATION IF EXISTS #{quote_identifier(publication_name(group_name))}",
           connection_url: conn_string,
           user: db_user(conn_string),
         )
@@ -144,7 +145,9 @@ module PgEasyReplicate
 
         Query.run(
           query:
-            "CREATE SUBSCRIPTION #{subscription_name(group_name)} CONNECTION '#{source_conn_string}' PUBLICATION #{publication_name(group_name)}",
+            "CREATE SUBSCRIPTION #{quote_identifier(subscription_name(group_name))}
+                      CONNECTION '#{source_conn_string}'
+                      PUBLICATION #{quote_identifier(publication_name(group_name))}",
           connection_url: target_conn_string,
           user: db_user(target_conn_string),
           transaction: false,

--- a/lib/pg_easy_replicate/query.rb
+++ b/lib/pg_easy_replicate/query.rb
@@ -17,12 +17,12 @@ module PgEasyReplicate
         if transaction
           r =
             conn.transaction do
-              conn.run("SET search_path to #{schema}") if schema
+              conn.run("SET search_path to #{quote_identifier(schema)}") if schema
               conn.run("SET statement_timeout to '5s'")
               conn.fetch(query).to_a
             end
         else
-          conn.run("SET search_path to #{schema}") if schema
+          conn.run("SET search_path to #{quote_identifier(schema)}") if schema
           conn.run("SET statement_timeout to '5s'")
           r = conn.fetch(query).to_a
         end


### PR DESCRIPTION
Add a helper method #quote_identifier for quoting unusual sql identifiers. Apply method to identifiers in DDL statements.

Rationale:
I'm working on a multi-tenanted app that uses UUIDs in the schema names, so I need to add quoting around the schema names for the generated DDL to be valid.