### PR TITLE
Escape db user name in queries

### DIFF
--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -164,8 +164,8 @@ module PgEasyReplicate
     def setup_internal_schema
       sql = <<~SQL
         create schema if not exists #{internal_schema_name};
-        grant usage on schema #{internal_schema_name} to #{db_user(source_db_url)};
-        grant create on schema #{internal_schema_name} to #{db_user(source_db_url)};
+        grant usage on schema #{internal_schema_name} to #{quote_ident(db_user(source_db_url))};
+        grant create on schema #{internal_schema_name} to #{quote_ident(db_user(source_db_url))};
       SQL
 
       Query.run(

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -43,7 +43,7 @@ module PgEasyReplicate
         .downcase
     end
 
-    def quote_identifier(sql_ident)
+    def quote_ident(sql_ident)
       PG::Connection.quote_ident(sql_ident)
     end
 

--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -94,8 +94,8 @@ module PgEasyReplicate
           .map do |table_name|
             Query.run(
               query:
-                "ALTER PUBLICATION #{quote_identifier(publication_name(group_name))}
-                        ADD TABLE #{quote_identifier(table_name)}",
+                "ALTER PUBLICATION #{quote_ident(publication_name(group_name))}
+                        ADD TABLE #{quote_ident(table_name)}",
               connection_url: conn_string,
               schema: schema,
             )
@@ -126,7 +126,8 @@ module PgEasyReplicate
           { publication_name: publication_name(group_name) },
         )
         Query.run(
-          query: "DROP PUBLICATION IF EXISTS #{quote_identifier(publication_name(group_name))}",
+          query:
+            "DROP PUBLICATION IF EXISTS #{quote_ident(publication_name(group_name))}",
           connection_url: conn_string,
           user: db_user(conn_string),
         )
@@ -149,9 +150,9 @@ module PgEasyReplicate
 
         Query.run(
           query:
-            "CREATE SUBSCRIPTION #{quote_identifier(subscription_name(group_name))}
+            "CREATE SUBSCRIPTION #{quote_ident(subscription_name(group_name))}
                       CONNECTION '#{source_conn_string}'
-                      PUBLICATION #{quote_identifier(publication_name(group_name))}",
+                      PUBLICATION #{quote_ident(publication_name(group_name))}",
           connection_url: target_conn_string,
           user: db_user(target_conn_string),
           transaction: false,
@@ -289,7 +290,7 @@ module PgEasyReplicate
         )
 
         alter_sql =
-          "ALTER USER #{db_user(source_db_url)} set default_transaction_read_only = true"
+          "ALTER USER #{quote_ident(db_user(source_db_url))} set default_transaction_read_only = true"
         Query.run(query: alter_sql, connection_url: source_db_url)
 
         kill_sql =
@@ -304,7 +305,7 @@ module PgEasyReplicate
         logger.info("Restoring connections")
 
         alter_sql =
-          "ALTER USER #{db_user(source_db_url)} set default_transaction_read_only = false"
+          "ALTER USER #{quote_ident(db_user(source_db_url))} set default_transaction_read_only = false"
         Query.run(query: alter_sql, connection_url: source_db_url)
       end
 

--- a/lib/pg_easy_replicate/query.rb
+++ b/lib/pg_easy_replicate/query.rb
@@ -17,12 +17,12 @@ module PgEasyReplicate
         if transaction
           r =
             conn.transaction do
-              conn.run("SET search_path to #{quote_identifier(schema)}") if schema
+              conn.run("SET search_path to #{quote_ident(schema)}") if schema
               conn.run("SET statement_timeout to '5s'")
               conn.fetch(query).to_a
             end
         else
-          conn.run("SET search_path to #{quote_identifier(schema)}") if schema
+          conn.run("SET search_path to #{quote_ident(schema)}") if schema
           conn.run("SET statement_timeout to '5s'")
           r = conn.fetch(query).to_a
         end


### PR DESCRIPTION
DB user name can contain special allowed character. Not wrapping them in escaped quotes result in syntax error

fixes: https://github.com/shayonj/pg_easy_replicate/issues/41