### PR TITLE
Require english lib so that $CHILD_STATUS is loaded

### DIFF
--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -5,6 +5,7 @@ require "ougai"
 require "pg"
 require "sequel"
 require "open3"
+require "English"
 
 require "pg_easy_replicate/helper"
 require "pg_easy_replicate/version"


### PR DESCRIPTION
This was missed when running a rubocop auto-correct over `$?`. Hence, fixing now by requiring English which containers `$CHILD_STATUS`

fixes: https://github.com/shayonj/pg_easy_replicate/issues/38

related: https://github.com/rubocop/rubocop/issues/1747