### PR TITLE
Quote indent username, dbname and schema in all places

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,10 +70,10 @@ jobs:
           export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
           sudo su - postgres -c "createuser -p 5432 -d -s -e -l james-bond"
-          sudo -u postgres psql -p 5432 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo -u postgres psql -p 5432 -c 'alter user "james-bond" with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           sudo su - postgres -c "createuser -p 5433 -d -s -e -l james-bond"
-          sudo -u postgres psql -p 5433 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo -u postgres psql -p 5433 -c 'alter user "james-bond" with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           # Remove the escaped quote since we are passing the pwd to psql
           # String: james-bond123@7!'3aaR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,27 +66,27 @@ jobs:
           sudo systemctl restart postgresql
 
           # Escape the quote because we are setting the password in PG
-          # String: jamesbond123@7!''3aaR
-          export PGPASSWORD='jamesbond123@7!'"'"''"'"'3aaR'
+          # String: james-bond123@7!''3aaR
+          export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
-          sudo su - postgres -c "createuser -p 5432 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5432 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo su - postgres -c "createuser -p 5432 -d -s -e -l james-bond"
+          sudo -u postgres psql -p 5432 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
-          sudo su - postgres -c "createuser -p 5433 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5433 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo su - postgres -c "createuser -p 5433 -d -s -e -l james-bond"
+          sudo -u postgres psql -p 5433 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           # Remove the escaped quote since we are passing the pwd to psql
-          # String: jamesbond123@7!'3aaR
-          export PGPASSWORD='jamesbond123@7!'"'"'3aaR'
-          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
-          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
+          # String: james-bond123@7!'3aaR
+          export PGPASSWORD='james-bond123@7!'"'"'3aaR'
+          psql -h localhost -d postgres -U james-bond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
+          psql -h localhost -d postgres -U james-bond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
 
           sudo systemctl restart postgresql@${{ matrix.pg.from }}-main.service
           sudo systemctl restart postgresql@${{ matrix.pg.to }}-main.service
           sudo systemctl restart postgresql
 
-          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'show wal_level;'
-          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'show wal_level;'
+          psql -h localhost -d postgres -U james-bond -p 5432 -c 'show wal_level;'
+          psql -h localhost -d postgres -U james-bond -p 5433 -c 'show wal_level;'
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -70,10 +70,10 @@ jobs:
           export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
           sudo su - postgres -c "createuser -p 5432 -d -s -e -l james-bond"
-          sudo -u postgres psql -p 5432 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo -u postgres psql -p 5432 -c 'alter user "james-bond" with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           sudo su - postgres -c "createuser -p 5433 -d -s -e -l james-bond"
-          sudo -u postgres psql -p 5433 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo -u postgres psql -p 5433 -c 'alter user "james-bond" with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           # Remove the escaped quote since we are passing the pwd to psql
           # String: james-bond123@7!'3aaR

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -66,27 +66,27 @@ jobs:
           sudo systemctl restart postgresql
 
           # Escape the quote because we are setting the password in PG
-          # String: jamesbond123@7!''3aaR
-          export PGPASSWORD='jamesbond123@7!'"'"''"'"'3aaR'
+          # String: james-bond123@7!''3aaR
+          export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
-          sudo su - postgres -c "createuser -p 5432 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5432 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo su - postgres -c "createuser -p 5432 -d -s -e -l james-bond"
+          sudo -u postgres psql -p 5432 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
-          sudo su - postgres -c "createuser -p 5433 -d -s -e -l jamesbond"
-          sudo -u postgres psql -p 5433 -c 'alter user jamesbond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
+          sudo su - postgres -c "createuser -p 5433 -d -s -e -l james-bond"
+          sudo -u postgres psql -p 5433 -c 'alter user james-bond with encrypted password '"'"''"$PGPASSWORD"''"'"';'
 
           # Remove the escaped quote since we are passing the pwd to psql
-          # String: jamesbond123@7!'3aaR
-          export PGPASSWORD='jamesbond123@7!'"'"'3aaR'
-          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
-          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
+          # String: james-bond123@7!'3aaR
+          export PGPASSWORD='james-bond123@7!'"'"'3aaR'
+          psql -h localhost -d postgres -U james-bond -p 5432 -c 'ALTER SYSTEM SET wal_level = logical;'
+          psql -h localhost -d postgres -U james-bond -p 5433 -c 'ALTER SYSTEM SET wal_level = logical;'
 
           sudo systemctl restart postgresql@${{ matrix.pg.from }}-main.service
           sudo systemctl restart postgresql@${{ matrix.pg.to }}-main.service
           sudo systemctl restart postgresql
 
-          psql -h localhost -d postgres -U jamesbond -p 5432 -c 'show wal_level;'
-          psql -h localhost -d postgres -U jamesbond -p 5433 -c 'show wal_level;'
+          psql -h localhost -d postgres -U james-bond -p 5432 -c 'show wal_level;'
+          psql -h localhost -d postgres -U james-bond -p 5433 -c 'show wal_level;'
 
       - name: Run RSpec
         run: bundle exec rspec spec/smoke_spec.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: jamesbond
-      POSTGRES_PASSWORD: jamesbond123@7!'3aaR
+      POSTGRES_USER: james-bond
+      POSTGRES_PASSWORD: james-bond123@7!'3aaR
       POSTGRES_DB: postgres
     command: >
       -c wal_level=logical
@@ -21,8 +21,8 @@ services:
     ports:
       - "5433:5432"
     environment:
-      POSTGRES_USER: jamesbond
-      POSTGRES_PASSWORD: jamesbond123@7!'3aaR
+      POSTGRES_USER: james-bond
+      POSTGRES_PASSWORD: james-bond123@7!'3aaR
       POSTGRES_DB: postgres
     command: >
       -c wal_level=logical

--- a/scripts/e2e-bootstrap.sh
+++ b/scripts/e2e-bootstrap.sh
@@ -3,13 +3,13 @@
 set -eo pipefail
 
 if [[ -z ${GITHUB_WORKFLOW} ]]; then
-  export SECONDARY_SOURCE_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@source_db/postgres"
+  export SECONDARY_SOURCE_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@source_db/postgres"
 fi
 
-export SOURCE_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
-export TARGET_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5433/postgres"
-export PGPASSWORD='jamesbond123@7!'"'"'3aaR'
+export SOURCE_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhost:5432/postgres"
+export TARGET_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhost:5433/postgres"
+export PGPASSWORD='james-bond123@7!'"'"'3aaR'
 
-pgbench --initialize -s 5 --foreign-keys --host localhost -U jamesbond -d postgres
+pgbench --initialize -s 5 --foreign-keys --host localhost -U james-bond -d postgres
 
 bundle exec bin/pg_easy_replicate config_check --copy-schema

--- a/scripts/e2e-start.sh
+++ b/scripts/e2e-start.sh
@@ -3,12 +3,12 @@
 set -eo pipefail
 
 if [[ -z ${GITHUB_WORKFLOW} ]]; then
-  export SECONDARY_SOURCE_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@source_db/postgres"
+  export SECONDARY_SOURCE_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@source_db/postgres"
 fi
 
-export SOURCE_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
-export TARGET_DB_URL="postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5433/postgres"
-export PGPASSWORD='jamesbond123@7!'"'"''"'"'3aaR'
+export SOURCE_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhost:5432/postgres"
+export TARGET_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhost:5433/postgres"
+export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
 # Bootstrap and cleanup
 echo "===== Performing Bootstrap and cleanup"

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -6,25 +6,25 @@ module DatabaseHelpers
   end
 
   # We are use url encoded password below.
-  # Original password is jamesbond123@7!'3aaR
-  def connection_url(user = "jamesbond")
-    "postgres://#{user}:jamesbond123%407%21%273aaR@localhost:5432/postgres"
+  # Original password is james-bond123@7!'3aaR
+  def connection_url(user = "james-bond")
+    "postgres://#{user}:james-bond123%407%21%273aaR@localhost:5432/postgres"
   end
 
-  def target_connection_url(user = "jamesbond")
-    "postgres://#{user}:jamesbond123%407%21%273aaR@localhost:5433/postgres"
+  def target_connection_url(user = "james-bond")
+    "postgres://#{user}:james-bond123%407%21%273aaR@localhost:5433/postgres"
   end
 
-  def docker_compose_target_connection_url(user = "jamesbond")
-    "postgres://#{user}:jamesbond123%407%21%273aaR@target_db/postgres"
+  def docker_compose_target_connection_url(user = "james-bond")
+    "postgres://#{user}:james-bond123%407%21%273aaR@target_db/postgres"
   end
 
-  def docker_compose_source_connection_url(user = "jamesbond")
+  def docker_compose_source_connection_url(user = "james-bond")
     return connection_url(user) if ENV["GITHUB_WORKFLOW"] # if running in CI/github actions
-    "postgres://#{user}:jamesbond123%407%21%273aaR@source_db/postgres"
+    "postgres://#{user}:james-bond123%407%21%273aaR@source_db/postgres"
   end
 
-  def setup_tables(user = "jamesbond", setup_target_db: true)
+  def setup_tables(user = "james-bond", setup_target_db: true)
     setup(connection_url(user), user)
     setup(target_connection_url(user), user) if setup_target_db
   end
@@ -33,78 +33,78 @@ module DatabaseHelpers
     [connection_url, target_connection_url].each do |url|
       PgEasyReplicate::Query.run(
         query:
-          "drop role if exists jamesbond_sup; create user jamesbond_sup with login superuser password 'jamesbond123@7!''3aaR';",
+          "drop role if exists #{PG::Connection.quote_ident("james-bond_sup")}; create user #{PG::Connection.quote_ident("james-bond_sup")} with login superuser password 'james-bond123@7!''3aaR';",
         connection_url: url,
-        user: "jamesbond",
+        user: "james-bond",
       )
 
       PgEasyReplicate::Query.run(
         query:
-          "drop role if exists no_sup; create user no_sup with login password 'jamesbond123@7!''3aaR';",
+          "drop role if exists no_sup; create user no_sup with login password 'james-bond123@7!''3aaR';",
         connection_url: url,
-        user: "jamesbond",
+        user: "james-bond",
       )
 
       # setup role
       PgEasyReplicate::Query.run(
         query:
-          "drop role if exists jamesbond_super_role; create role jamesbond_super_role with createdb createrole replication;",
+          "drop role if exists #{PG::Connection.quote_ident("james-bond_super_role")}; create role #{PG::Connection.quote_ident("james-bond_super_role")} with createdb createrole replication;",
         connection_url: url,
-        user: "jamesbond",
+        user: "james-bond",
       )
 
       # setup user with role
       sql = <<~SQL
-        drop role if exists jamesbond_role_regular;
-        create role jamesbond_role_regular WITH createrole createdb replication LOGIN PASSWORD 'jamesbond123@7!''3aaR'; grant jamesbond_super_role to jamesbond_role_regular;
-        grant all privileges on database postgres TO jamesbond_role_regular;
+        drop role if exists #{PG::Connection.quote_ident("james-bond_role_regular")};
+        create role #{PG::Connection.quote_ident("james-bond_role_regular")} WITH createrole createdb replication LOGIN PASSWORD 'james-bond123@7!''3aaR'; grant #{PG::Connection.quote_ident("james-bond_super_role")} to #{PG::Connection.quote_ident("james-bond_role_regular")};
+        grant all privileges on database postgres TO #{PG::Connection.quote_ident("james-bond_role_regular")};
       SQL
       PgEasyReplicate::Query.run(
         query: sql,
         connection_url: url,
-        user: "jamesbond",
+        user: "james-bond",
       )
     end
   end
 
   def cleanup_roles
     %w[
-      jamesbond_sup
+      james-bond_sup
       no_sup
-      jamesbond_role_regular
-      jamesbond_super_role
+      james-bond_role_regular
+      james-bond_super_role
     ].each do |role|
-      if role == "jamesbond_role_regular"
+      if role == "james-bond_role_regular"
         PgEasyReplicate::Query.run(
           query:
-            "revoke all privileges on database postgres from jamesbond_role_regular;",
+            "revoke all privileges on database postgres from #{PG::Connection.quote_ident("james-bond_role_regular")};",
           connection_url: connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
 
         PgEasyReplicate::Query.run(
           query:
-            "revoke all privileges on database postgres from jamesbond_role_regular;",
+            "revoke all privileges on database postgres from #{PG::Connection.quote_ident("james-bond_role_regular")};",
           connection_url: target_connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
       end
 
       PgEasyReplicate::Query.run(
-        query: "drop role if exists #{role};",
+        query: "drop role if exists #{PG::Connection.quote_ident(role)};",
         connection_url: connection_url,
-        user: "jamesbond",
+        user: "james-bond",
       )
 
       PgEasyReplicate::Query.run(
-        query: "drop role if exists #{role};",
+        query: "drop role if exists #{PG::Connection.quote_ident(role)};",
         connection_url: target_connection_url,
-        user: "jamesbond",
+        user: "james-bond",
       )
     end
   end
 
-  def setup(connection_url, user = "jamesbond")
+  def setup(connection_url, user = "james-bond")
     PgEasyReplicate::Query.run(
       query: "DROP SCHEMA IF EXISTS #{test_schema} CASCADE;",
       connection_url: connection_url,
@@ -138,13 +138,13 @@ module DatabaseHelpers
     PgEasyReplicate::Query.run(
       query: "DROP SCHEMA IF EXISTS #{test_schema} CASCADE;",
       connection_url: connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
 
     PgEasyReplicate::Query.run(
       query: "DROP SCHEMA IF EXISTS #{test_schema} CASCADE;",
       connection_url: target_connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -154,7 +154,7 @@ module DatabaseHelpers
         "SELECT schema_name FROM information_schema.schemata WHERE schema_name = '#{PgEasyReplicate.internal_schema_name}';",
       connection_url: connection_url,
       schema: PgEasyReplicate.internal_schema_name,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -164,7 +164,7 @@ module DatabaseHelpers
         "SELECT table_name FROM information_schema.tables WHERE  table_name = 'groups'",
       connection_url: connection_url,
       schema: PgEasyReplicate.internal_schema_name,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -173,7 +173,7 @@ module DatabaseHelpers
       query:
         "select rolcreatedb, rolcreaterole, rolcanlogin, rolsuper from pg_authid where rolname = 'pger_su_h1a4fb';",
       connection_url: connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -182,7 +182,7 @@ module DatabaseHelpers
       query:
         "select subname, subpublications, subslotname, subenabled from pg_subscription;",
       connection_url: connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -190,7 +190,7 @@ module DatabaseHelpers
     PgEasyReplicate::Query.run(
       query: "select * from pg_publication_tables;",
       connection_url: connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -198,7 +198,7 @@ module DatabaseHelpers
     PgEasyReplicate::Query.run(
       query: "select pubname from pg_catalog.pg_publication",
       connection_url: connection_url,
-      user: "jamesbond",
+      user: "james-bond",
     )
   end
 
@@ -214,9 +214,9 @@ module DatabaseHelpers
   def self.populate_env_vars
     ENV[
       "SOURCE_DB_URL"
-    ] = "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5432/postgres"
+    ] = "postgres://james-bond:james-bond123%407%21%273aaR@localhost:5432/postgres"
     ENV[
       "TARGET_DB_URL"
-    ] = "postgres://jamesbond:jamesbond123%407%21%273aaR@localhost:5433/postgres"
+    ] = "postgres://james-bond:james-bond123%407%21%273aaR@localhost:5433/postgres"
   end
 end

--- a/spec/pg_easy_replicate/group_spec.rb
+++ b/spec/pg_easy_replicate/group_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe(PgEasyReplicate::Group) do
           query: columns_sql,
           connection_url: connection_url,
           schema: PgEasyReplicate.internal_schema_name,
-          user: "jamesbond",
+          user: "james-bond",
         )
       expect(columns).to eq(
         [

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -457,18 +457,18 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
   # So all this spec does in vanilla postgres is to raise error below.
   describe ".switchover with special user role" do
     before do
-      ENV["SOURCE_DB_URL"] = connection_url("jamesbond_role_regular")
-      ENV["TARGET_DB_URL"] = target_connection_url("jamesbond_role_regular")
+      ENV["SOURCE_DB_URL"] = connection_url("james-bond_role_regular")
+      ENV["TARGET_DB_URL"] = target_connection_url("james-bond_role_regular")
 
       setup_roles
-      setup_tables("jamesbond_role_regular")
+      setup_tables("james-bond_role_regular")
 
-      PgEasyReplicate.assert_config(special_user_role: "jamesbond_super_role")
+      PgEasyReplicate.assert_config(special_user_role: "james-bond_super_role")
       PgEasyReplicate.bootstrap(
         {
           group_name: "cluster1",
           schema: test_schema,
-          special_user_role: "jamesbond_super_role",
+          special_user_role: "james-bond_super_role",
         },
       )
     end
@@ -485,9 +485,9 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
     it "succesfully raises create subscription super user error" do
       conn1 =
         PgEasyReplicate::Query.connect(
-          connection_url: connection_url("jamesbond_role_regular"),
+          connection_url: connection_url("james-bond_role_regular"),
           schema: test_schema,
-          user: "jamesbond_role_regular",
+          user: "james-bond_role_regular",
         )
       conn1[:items].insert(name: "Foo1")
       expect(conn1[:items].first[:name]).to eq("Foo1")
@@ -495,14 +495,14 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       # Expect no item in target DB
       conn2 =
         PgEasyReplicate::Query.connect(
-          connection_url: target_connection_url("jamesbond_role_regular"),
+          connection_url: target_connection_url("james-bond_role_regular"),
           schema: test_schema,
-          user: "jamesbond_role_regular",
+          user: "james-bond_role_regular",
         )
       expect(conn2[:items].first).to be_nil
 
       ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url(
-        "jamesbond_super_role",
+        "james-bond_super_role",
       )
 
       expect do
@@ -544,8 +544,8 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
 
       # described_class.switchover(
       #   group_name: "cluster1",
-      #   source_conn_string: connection_url("jamesbond_role_regular"),
-      #   target_conn_string: target_connection_url("jamesbond_role_regular"),
+      #   source_conn_string: connection_url("james-bond_role_regular"),
+      #   target_conn_string: target_connection_url("james-bond_role_regular"),
       # )
 
       # expect(PgEasyReplicate::Group.find("cluster1")).to include(

--- a/spec/pg_easy_replicate/query_spec.rb
+++ b/spec/pg_easy_replicate/query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(PgEasyReplicate::Query) do
         described_class.run(
           query: "SELECT 'FooBar' as result",
           connection_url: connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
 
       expect(result).to eq([{ result: "FooBar" }])
@@ -20,7 +20,7 @@ RSpec.describe(PgEasyReplicate::Query) do
         described_class.run(
           query: "show statement_timeout",
           connection_url: connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
 
       expect(result).to eq([{ statement_timeout: "5s" }])
@@ -37,7 +37,7 @@ RSpec.describe(PgEasyReplicate::Query) do
           query: query,
           connection_url: connection_url,
           schema: "pger_test",
-          user: "jamesbond",
+          user: "james-bond",
         )
       }.to raise_error(PG::DependentObjectsStillExist)
     end
@@ -48,7 +48,7 @@ RSpec.describe(PgEasyReplicate::Query) do
           query: "select * from sellers;",
           connection_url: connection_url,
           schema: "pger_test",
-          user: "jamesbond",
+          user: "james-bond",
         ).to_a,
       ).to eq([])
     end

--- a/spec/pg_easy_replicate/stats_spec.rb
+++ b/spec/pg_easy_replicate/stats_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe(PgEasyReplicate::Stats) do
         replay_lag: kind_of(BigDecimal),
         state: kind_of(String),
         sync_state: kind_of(String),
-        user_name: "jamesbond",
+        user_name: "james-bond",
         write_lag: kind_of(BigDecimal),
       )
     end

--- a/spec/pg_easy_replicate_spec.rb
+++ b/spec/pg_easy_replicate_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe(PgEasyReplicate) do
         expect(
           described_class.send(
             :is_super_user?,
-            connection_url("jamesbond_sup"),
+            connection_url("james-bond_sup"),
           ),
         ).to be(true)
       end
@@ -137,8 +137,8 @@ RSpec.describe(PgEasyReplicate) do
         expect(
           described_class.send(
             :is_super_user?,
-            connection_url("jamesbond_role_regular"),
-            "jamesbond_super_role",
+            connection_url("james-bond_role_regular"),
+            "james-bond_super_role",
           ),
         ).to be(true)
       end
@@ -168,7 +168,7 @@ RSpec.describe(PgEasyReplicate) do
     end
 
     describe ".bootstrap" do
-      before { setup_tables("jamesbond", setup_target_db: false) }
+      before { setup_tables("james-bond", setup_target_db: false) }
 
       after do
         described_class.cleanup({ everything: true, group_name: "cluster1" })
@@ -267,7 +267,7 @@ RSpec.describe(PgEasyReplicate) do
           PgEasyReplicate::Query.connect(
             connection_url: target_connection_url,
             schema: test_schema,
-            user: "jamesbond",
+            user: "james-bond",
           )
         expect(conn.fetch("SELECT * FROM items").to_a).to eq([])
       end
@@ -333,7 +333,7 @@ RSpec.describe(PgEasyReplicate) do
     end
 
     describe ".import_schema" do
-      before { setup_tables("jamesbond", setup_target_db: false) }
+      before { setup_tables("james-bond", setup_target_db: false) }
 
       after do
         teardown_tables
@@ -348,7 +348,7 @@ RSpec.describe(PgEasyReplicate) do
           PgEasyReplicate::Query.connect(
             connection_url: target_connection_url,
             schema: test_schema,
-            user: "jamesbond",
+            user: "james-bond",
           )
         expect(conn.fetch("SELECT * FROM items").to_a).to eq([])
       end

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe("SmokeSpec") do
         PgEasyReplicate::Query.run(
           query: "select count(*) from pgbench_accounts",
           connection_url: connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
       expect(r).to eq([{ count: 500_000 }])
       last_count = r.last[:count]
@@ -26,7 +26,7 @@ RSpec.describe("SmokeSpec") do
             PgEasyReplicate::Query.run(
               query: sql,
               connection_url: connection_url,
-              user: "jamesbond",
+              user: "james-bond",
             )
           rescue => e
             if e.message.include?(
@@ -35,7 +35,7 @@ RSpec.describe("SmokeSpec") do
               PgEasyReplicate::Query.run(
                 query: sql,
                 connection_url: target_connection_url,
-                user: "jamesbond",
+                user: "james-bond",
               )
             else
               raise
@@ -56,7 +56,7 @@ RSpec.describe("SmokeSpec") do
         PgEasyReplicate::Query.run(
           query: "select count(*) from pgbench_accounts",
           connection_url: target_connection_url,
-          user: "jamesbond",
+          user: "james-bond",
         )
       expect(r).to eq([{ count: 503_000 }])
       expect(


### PR DESCRIPTION
Follow up to https://github.com/shayonj/pg_easy_replicate/pull/42.
Using `james-bond` instead of `jamesbond` in specs to test for cases where username can contain
special chars. 