### PR TITLE
Drop existing user with privileges when bootstrapping

### DIFF
--- a/spec/pg_easy_replicate_spec.rb
+++ b/spec/pg_easy_replicate_spec.rb
@@ -167,6 +167,22 @@ RSpec.describe(PgEasyReplicate) do
       end
     end
 
+    describe ".drop_user" do
+      it "drops the user" do
+        described_class.create_user(conn_string: connection_url)
+
+        expect(described_class.user_exists?(conn_string: connection_url)).to be(
+          true,
+        )
+
+        described_class.drop_user(conn_string: connection_url)
+
+        expect(described_class.user_exists?(conn_string: connection_url)).to be(
+          false,
+        )
+      end
+    end
+
     describe ".bootstrap" do
       before { setup_tables("james-bond", setup_target_db: false) }
 


### PR DESCRIPTION
Its possible for there to be hangover from previous failed runs where the internal user may exist in the DB. When that happens, the bootstrap shouldn't fail but attempt to revoke privileges and drop the user, to start fresh again.

https://github.com/shayonj/pg_easy_replicate/issues/73