### PR TITLE
Don't attempt to drop and recreate unique indices

### DIFF
--- a/lib/pg_easy_replicate/index_manager.rb
+++ b/lib/pg_easy_replicate/index_manager.rb
@@ -75,6 +75,7 @@ module PgEasyReplicate
             AND n.oid = t.relnamespace
             AND t.relkind = 'r'  -- only find indexes of tables
             AND ix.indisprimary = FALSE  -- exclude primary keys
+            AND ix.indisunique = FALSE  -- exclude unique indexes
             AND n.nspname = '#{schema}'
             AND t.relname IN (#{table_list})
         ORDER BY

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -117,19 +117,25 @@ module DatabaseHelpers
       "CREATE SCHEMA IF NOT EXISTS #{test_schema}; SET search_path TO #{test_schema};",
     )
 
-    return if conn.table_exists?("sellers")
-    conn.create_table("sellers") do
-      primary_key(:id)
-      column(:name, String)
-      column(:last_login, Time)
-      index(:name, unique: false)
+    unless conn.table_exists?("sellers")
+      conn.create_table("sellers") do
+        primary_key(:id)
+        column(:name, String, unique: true)
+        column(:last_login, Time)
+        index(:id)
+        index(:last_login)
+      end
     end
 
-    return if conn.table_exists?("items")
-    conn.create_table("items") do
-      primary_key(:id)
-      column(:name, String)
-      column(:last_purchase_at, Time)
+    unless conn.table_exists?("items")
+      conn.create_table("items") do
+        primary_key(:id)
+        column(:name, String)
+        column(:last_purchase_at, Time)
+        foreign_key(:seller_id, :sellers, on_delete: :cascade)
+        index(:seller_id)
+        index(:id)
+      end
     end
   ensure
     conn&.disconnect

--- a/spec/pg_easy_replicate/index_manager_spec.rb
+++ b/spec/pg_easy_replicate/index_manager_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
     end
 
-    it "fetches index information from the given connection string" do
+    it "fetches index information from the given connection string with no unique & PK indices" do
       result =
         described_class.fetch_indices(
           conn_string: connection_url,
@@ -25,10 +25,16 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       expect(result).to eq(
         [
           {
-            index_definition:
-              "CREATE INDEX sellers_name_index ON pger_test.sellers USING btree (name)",
-            index_name: "sellers_name_index",
             table_name: "sellers",
+            index_name: "sellers_id_index",
+            index_definition:
+              "CREATE INDEX sellers_id_index ON pger_test.sellers USING btree (id)",
+          },
+          {
+            table_name: "sellers",
+            index_name: "sellers_last_login_index",
+            index_definition:
+              "CREATE INDEX sellers_last_login_index ON pger_test.sellers USING btree (last_login)",
           },
         ],
       )
@@ -46,7 +52,7 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
     end
 
-    it "drops non-primary indices from the target database" do
+    it "drops non-primary + unique indices from the target database" do
       # Ensure index exists
       result =
         described_class.fetch_indices(
@@ -58,10 +64,16 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       expect(result).to eq(
         [
           {
-            index_definition:
-              "CREATE INDEX sellers_name_index ON pger_test.sellers USING btree (name)",
-            index_name: "sellers_name_index",
             table_name: "sellers",
+            index_name: "sellers_id_index",
+            index_definition:
+              "CREATE INDEX sellers_id_index ON pger_test.sellers USING btree (id)",
+          },
+          {
+            table_name: "sellers",
+            index_name: "sellers_last_login_index",
+            index_definition:
+              "CREATE INDEX sellers_last_login_index ON pger_test.sellers USING btree (last_login)",
           },
         ],
       )
@@ -107,10 +119,16 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       expect(result).to eq(
         [
           {
-            index_definition:
-              "CREATE INDEX sellers_name_index ON pger_test.sellers USING btree (name)",
-            index_name: "sellers_name_index",
             table_name: "sellers",
+            index_name: "sellers_id_index",
+            index_definition:
+              "CREATE INDEX sellers_id_index ON pger_test.sellers USING btree (id)",
+          },
+          {
+            table_name: "sellers",
+            index_name: "sellers_last_login_index",
+            index_definition:
+              "CREATE INDEX sellers_last_login_index ON pger_test.sellers USING btree (last_login)",
           },
         ],
       )
@@ -151,10 +169,16 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       expect(result).to eq(
         [
           {
-            index_definition:
-              "CREATE INDEX sellers_name_index ON pger_test.sellers USING btree (name)",
-            index_name: "sellers_name_index",
             table_name: "sellers",
+            index_name: "sellers_id_index",
+            index_definition:
+              "CREATE INDEX sellers_id_index ON pger_test.sellers USING btree (id)",
+          },
+          {
+            table_name: "sellers",
+            index_name: "sellers_last_login_index",
+            index_definition:
+              "CREATE INDEX sellers_last_login_index ON pger_test.sellers USING btree (last_login)",
           },
         ],
       )

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -448,10 +448,16 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       expect(result).to eq(
         [
           {
-            index_definition:
-              "CREATE INDEX sellers_name_index ON pger_test.sellers USING btree (name)",
-            index_name: "sellers_name_index",
             table_name: "sellers",
+            index_name: "sellers_id_index",
+            index_definition:
+              "CREATE INDEX sellers_id_index ON pger_test.sellers USING btree (id)",
+          },
+          {
+            table_name: "sellers",
+            index_name: "sellers_last_login_index",
+            index_definition:
+              "CREATE INDEX sellers_last_login_index ON pger_test.sellers USING btree (last_login)",
           },
         ],
       )


### PR DESCRIPTION
Droping unique indices is not possible w/o having to drop and recreate the constraint.

We could in future consider doing that if there are significant performance gains. Otherwise, just don't attempt to drop/recreate it.

We'd still gain on the performance improvement from having dropped other indices before copy

https://github.com/shayonj/pg_easy_replicate/issues/8#issuecomment-1901783088