### PR TITLE
Extend config check to assert for REPLICA IDENTITY on tables and drop index bug fix

### DIFF
--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -16,10 +16,20 @@ module PgEasyReplicate
                   aliases: "-c",
                   boolean: true,
                   desc: "Copy schema to the new database"
+    method_option :tables,
+                  aliases: "-t",
+                  desc:
+                    "Comma separated list of table names. Default: All tables"
+    method_option :schema_name,
+                  aliases: "-s",
+                  desc:
+                    "Name of the schema tables are in, only required if passing list of tables"
     def config_check
       PgEasyReplicate.assert_config(
         special_user_role: options[:special_user_role],
         copy_schema: options[:copy_schema],
+        tables: options[:tables],
+        schema_name: options[:schema_name],
       )
 
       puts "✅ Config is looking good."

--- a/lib/pg_easy_replicate/index_manager.rb
+++ b/lib/pg_easy_replicate/index_manager.rb
@@ -17,7 +17,7 @@ module PgEasyReplicate
         tables: tables,
         schema: schema,
       ).each do |index|
-        drop_sql = "DROP INDEX CONCURRENTLY #{index[:index_name]};"
+        drop_sql = "DROP INDEX CONCURRENTLY #{schema}.#{index[:index_name]};"
 
         Query.run(
           query: drop_sql,
@@ -56,8 +56,8 @@ module PgEasyReplicate
     end
 
     def self.fetch_indices(conn_string:, tables:, schema:)
-      return [] if tables.split(",").empty?
-      table_list = tables.split(",").map { |table| "'#{table}'" }.join(",")
+      return [] if tables.empty?
+      table_list = tables.map { |table| "'#{table}'" }.join(",")
 
       sql = <<-SQL
         SELECT

--- a/spec/pg_easy_replicate/index_manager_spec.rb
+++ b/spec/pg_easy_replicate/index_manager_spec.rb
@@ -18,12 +18,24 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       result =
         described_class.fetch_indices(
           conn_string: connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
       expect(result).to eq(
         [
+          {
+            table_name: "items",
+            index_name: "items_id_index",
+            index_definition:
+              "CREATE INDEX items_id_index ON pger_test.items USING btree (id)",
+          },
+          {
+            table_name: "items",
+            index_name: "items_seller_id_index",
+            index_definition:
+              "CREATE INDEX items_seller_id_index ON pger_test.items USING btree (seller_id)",
+          },
           {
             table_name: "sellers",
             index_name: "sellers_id_index",
@@ -57,12 +69,24 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       result =
         described_class.fetch_indices(
           conn_string: target_connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
       expect(result).to eq(
         [
+          {
+            table_name: "items",
+            index_name: "items_id_index",
+            index_definition:
+              "CREATE INDEX items_id_index ON pger_test.items USING btree (id)",
+          },
+          {
+            table_name: "items",
+            index_name: "items_seller_id_index",
+            index_definition:
+              "CREATE INDEX items_seller_id_index ON pger_test.items USING btree (seller_id)",
+          },
           {
             table_name: "sellers",
             index_name: "sellers_id_index",
@@ -81,14 +105,14 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       described_class.drop_indices(
         source_conn_string: connection_url,
         target_conn_string: target_connection_url,
-        tables: "sellers, items",
+        tables: %w[sellers items],
         schema: test_schema,
       )
 
       result =
         described_class.fetch_indices(
           conn_string: target_connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
@@ -112,12 +136,24 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       result =
         described_class.fetch_indices(
           conn_string: target_connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
       expect(result).to eq(
         [
+          {
+            table_name: "items",
+            index_name: "items_id_index",
+            index_definition:
+              "CREATE INDEX items_id_index ON pger_test.items USING btree (id)",
+          },
+          {
+            table_name: "items",
+            index_name: "items_seller_id_index",
+            index_definition:
+              "CREATE INDEX items_seller_id_index ON pger_test.items USING btree (seller_id)",
+          },
           {
             table_name: "sellers",
             index_name: "sellers_id_index",
@@ -136,7 +172,7 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       described_class.drop_indices(
         source_conn_string: connection_url,
         target_conn_string: target_connection_url,
-        tables: "sellers, items",
+        tables: %w[sellers items],
         schema: test_schema,
       )
 
@@ -145,7 +181,7 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       result =
         described_class.fetch_indices(
           conn_string: target_connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
@@ -154,7 +190,7 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       described_class.recreate_indices(
         source_conn_string: connection_url,
         target_conn_string: target_connection_url,
-        tables: "sellers, items",
+        tables: %w[sellers items],
         schema: test_schema,
       )
 
@@ -162,12 +198,24 @@ RSpec.describe(PgEasyReplicate::IndexManager) do
       result =
         described_class.fetch_indices(
           conn_string: target_connection_url,
-          tables: "sellers, items",
+          tables: %w[sellers items],
           schema: test_schema,
         )
 
       expect(result).to eq(
         [
+          {
+            table_name: "items",
+            index_name: "items_id_index",
+            index_definition:
+              "CREATE INDEX items_id_index ON pger_test.items USING btree (id)",
+          },
+          {
+            table_name: "items",
+            index_name: "items_seller_id_index",
+            index_definition:
+              "CREATE INDEX items_seller_id_index ON pger_test.items USING btree (seller_id)",
+          },
           {
             table_name: "sellers",
             index_name: "sellers_id_index",


### PR DESCRIPTION


- config check now performs an additional check to ensure all tables replicating (or about to be) have some form of replica identity setup. This way, if when the subscription starts, it doesn't fail hard if the one of the tables cannot be replicate. This usually involves having a PK, index or FULL REPLICA identity
- Bug fix with drop indices when custom set of tables are passed
- Refactor a bit of tables list is derived