### PR TITLE
Quote table name in the `VACUUM` SQL

### DIFF
--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -365,7 +365,7 @@ module PgEasyReplicate
           )
 
           Query.run(
-            query: "VACUUM VERBOSE ANALYZE #{t};",
+            query: "VACUUM VERBOSE ANALYZE #{quote_ident(t)};",
             connection_url: conn_string,
             schema: schema,
             transaction: false,


### PR DESCRIPTION
Table name could use reserved keyword from SQL. For example, the following is valid
```SQL
create table "table" (id int);
insert into "table" (id) values (1);
select * from "table"
```
NOTE the quoting