### PR TITLE
Exclude tables created by extensions

### DIFF
--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -80,7 +80,7 @@ module PgEasyReplicate
       if tables.size > 0
         tables
       else
-        list_all_tables(schema: schema, conn_string: conn_string)
+        list_all_tables(schema: schema, conn_string: conn_string) - %w[ spatial_ref_sys ]
       end
     end
 

--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -365,7 +365,7 @@ module PgEasyReplicate
           )
 
           Query.run(
-            query: "VACUUM VERBOSE ANALYZE #{t};",
+            query: "VACUUM VERBOSE ANALYZE #{quote_ident(t)};",
             connection_url: conn_string,
             schema: schema,
             transaction: false,

--- a/spec/database_helpers.rb
+++ b/spec/database_helpers.rb
@@ -137,6 +137,17 @@ module DatabaseHelpers
         index(:id)
       end
     end
+
+    unless conn.table_exists?("spatial_ref_sys")
+      conn.create_table("spatial_ref_sys") do
+        primary_key(:id)
+        column(:name, String)
+        column(:last_purchase_at, Time)
+        foreign_key(:seller_id, :sellers, on_delete: :cascade)
+        index(:seller_id)
+        index(:id)
+      end
+    end
   ensure
     conn&.disconnect
   end

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -73,11 +73,16 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
     end
 
     it "succesfully for all tables" do
+      tables = described_class.determine_tables(
+        schema: test_schema,
+        conn_string: connection_url,
+      )
+
       described_class.add_tables_to_publication(
         group_name: "cluster1",
         schema: test_schema,
         conn_string: connection_url,
-        tables: %w[items sellers],
+        tables: tables,
       )
 
       expect(pg_publication_tables(connection_url: connection_url)).to eq(
@@ -133,7 +138,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
           schema: test_schema,
           conn_string: connection_url,
         )
-      expect(r.sort).to eq(%w[items sellers])
+      expect(r.sort).to eq(%w[items sellers spatial_ref_sys])
     end
   end
 


### PR DESCRIPTION
PostGIS creates `spatial_ref_sys` table which should never be replicated