### PR TITLE
Proposal : Add cmd to exclude tables from sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,17 @@ $ pg_easy_replicate switchover  --group-name database-cluster-2
 ...
 ```
 
+## Exclude tables from replication
+
+By default all tables are added for replication but you can exclude tables if necessary. Example
+
+```bash
+...
+$ pg_easy_replicate bootstrap --group-name database-cluster-1 --copy-schema
+$ pg_easy_replicate start_sync --group-name database-cluster-1 --schema-name public --exclude_tables "events"
+...
+```
+
 ### Cleanup
 
 Use `cleanup` if you want to remove all bootstrapped data for the specified group. Additionally you can pass `-e` or `--everything` in order to clean up all schema changes for bootstrapped tables, users and any publication/subscription data.

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -30,6 +30,7 @@ module PgEasyReplicate
       special_user_role: nil,
       copy_schema: false,
       tables: "",
+      exclude_tables: "",
       schema_name: nil
     )
       abort_with("SOURCE_DB_URL is missing") if source_db_url.nil?
@@ -65,6 +66,7 @@ module PgEasyReplicate
               tables_have_replica_identity?(
                 conn_string: source_db_url,
                 tables: tables,
+                exclude_tables: exclude_tables,
                 schema_name: schema_name,
               ),
           }
@@ -77,6 +79,7 @@ module PgEasyReplicate
       special_user_role: nil,
       copy_schema: false,
       tables: "",
+      exclude_tables: "",
       schema_name: nil
     )
       config_hash =
@@ -84,6 +87,7 @@ module PgEasyReplicate
           special_user_role: special_user_role,
           copy_schema: copy_schema,
           tables: tables,
+          exclude_tables: exclude_tables,
           schema_name: schema_name,
         )
 
@@ -103,8 +107,16 @@ module PgEasyReplicate
         abort_with("User on source database does not have super user privilege")
       end
 
-      if tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
-        abort_with("Schema name is required if tables are passed")
+      if tables.any? && exclude_tables.any?
+        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
+      elsif tables.any?
+        if tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
+          abort_with("Schema name is required if tables are passed")
+        end
+      else
+        if exclude_tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
+          abort_with("Schema name is required if exclude tables are passed")
+        end
       end
 
       unless config_hash.dig(:tables_have_replica_identity)
@@ -390,6 +402,7 @@ module PgEasyReplicate
     def tables_have_replica_identity?(
       conn_string:,
       tables: "",
+      exclude_tables: "",
       schema_name: nil
     )
       schema_name ||= "public"
@@ -399,6 +412,7 @@ module PgEasyReplicate
           schema: schema_name,
           conn_string: source_db_url,
           list: tables,
+          exclude_list: exclude_tables,
         )
       return false if table_list.empty?
 

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -111,14 +111,17 @@ module PgEasyReplicate
         abort_with("User on source database does not have super user privilege")
       end
 
+      tables = tables.is_a?(Array) ? tables : tables&.split(",") || []
+      exclude_tables = exclude_tables.is_a?(Array) ? exclude_tables : exclude_tables&.split(",") || []
+
       if !tables.empty? && !exclude_tables.empty?
         abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
       elsif !tables.empty?
-        if tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
+        if tables.size > 0 && (schema_name.nil? || schema_name == "")
           abort_with("Schema name is required if tables are passed")
         end
       else
-        if exclude_tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
+        if exclude_tables.size > 0 && (schema_name.nil? || schema_name == "")
           abort_with("Schema name is required if exclude tables are passed")
         end
       end

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -111,19 +111,17 @@ module PgEasyReplicate
         abort_with("User on source database does not have super user privilege")
       end
 
-      tables = tables.is_a?(Array) ? tables : tables&.split(",") || []
-      exclude_tables = exclude_tables.is_a?(Array) ? exclude_tables : exclude_tables&.split(",") || []
+      table_list = tables.is_a?(Array) ? tables : tables&.split(",") || []
+      exclude_table_list = exclude_tables.is_a?(Array) ? exclude_tables : exclude_tables&.split(",") || []
 
-      if !tables.empty? && !exclude_tables.empty?
+      if !table_list.empty? && !exclude_table_list.empty?
         abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-      elsif !tables.empty?
-        if tables.size > 0 && (schema_name.nil? || schema_name == "")
+      elsif !table_list.empty?
+        if table_list.size > 0 && (schema_name.nil? || schema_name == "")
           abort_with("Schema name is required if tables are passed")
         end
-      else
-        if exclude_tables.size > 0 && (schema_name.nil? || schema_name == "")
+      elsif exclude_table_list.size > 0 && (schema_name.nil? || schema_name == "")
           abort_with("Schema name is required if exclude tables are passed")
-        end
       end
 
       unless config_hash.dig(:tables_have_replica_identity)

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -111,18 +111,7 @@ module PgEasyReplicate
         abort_with("User on source database does not have super user privilege")
       end
 
-      table_list = tables.is_a?(Array) ? tables : tables&.split(",") || []
-      exclude_table_list = exclude_tables.is_a?(Array) ? exclude_tables : exclude_tables&.split(",") || []
-
-      if !table_list.empty? && !exclude_table_list.empty?
-        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-      elsif !table_list.empty?
-        if table_list.size > 0 && (schema_name.nil? || schema_name == "")
-          abort_with("Schema name is required if tables are passed")
-        end
-      elsif exclude_table_list.size > 0 && (schema_name.nil? || schema_name == "")
-          abort_with("Schema name is required if exclude tables are passed")
-      end
+      validate_table_lists(tables, exclude_tables, schema_name)
 
       unless config_hash.dig(:tables_have_replica_identity)
         abort_with(

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -35,6 +35,10 @@ module PgEasyReplicate
     )
       abort_with("SOURCE_DB_URL is missing") if source_db_url.nil?
       abort_with("TARGET_DB_URL is missing") if target_db_url.nil?
+      
+      if !tables.empty? && !exclude_tables.empty?
+        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
+      end
 
       system("which pg_dump")
       pg_dump_exists = $CHILD_STATUS.success?
@@ -107,9 +111,9 @@ module PgEasyReplicate
         abort_with("User on source database does not have super user privilege")
       end
 
-      if tables.any? && exclude_tables.any?
+      if !tables.empty? && !exclude_tables.empty?
         abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-      elsif tables.any?
+      elsif !tables.empty?
         if tables.split(",").size > 0 && (schema_name.nil? || schema_name == "")
           abort_with("Schema name is required if tables are passed")
         end

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -21,6 +21,11 @@ module PgEasyReplicate
                   default: "",
                   desc:
                     "Comma separated list of table names. Default: All tables"
+    method_option :exclude_tables,
+                  aliases: "-e",
+                  default: "",
+                  desc:
+                    "Comma separated list of table names to exclude. Default: None"
     method_option :schema_name,
                   aliases: "-s",
                   desc:
@@ -30,6 +35,7 @@ module PgEasyReplicate
         special_user_role: options[:special_user_role],
         copy_schema: options[:copy_schema],
         tables: options[:tables],
+        exclude_tables: options[:exclude_tables],
         schema_name: options[:schema_name],
       )
 
@@ -91,6 +97,11 @@ module PgEasyReplicate
                   default: "",
                   desc:
                     "Comma separated list of table names. Default: All tables"
+    method_option :exclude_tables,
+                  aliases: "-e",
+                  default: "",
+                  desc:
+                    "Comma separated list of table names to exclude. Default: None"
     method_option :recreate_indices_post_copy,
                   type: :boolean,
                   default: true,

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -78,10 +78,9 @@ module PgEasyReplicate
       
       tables = convert_to_array(list)
       exclude_tables = convert_to_array(exclude_list)
+      validate_table_lists(tables, exclude_tables, schema)
 
-      if !tables.empty? && !exclude_tables.empty?
-        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-      elsif !tables.empty?
+      if !tables.empty?
         tables
       else
         all_tables = list_all_tables(schema: schema, conn_string: conn_string)

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -80,11 +80,11 @@ module PgEasyReplicate
       exclude_tables = convert_to_array(exclude_list)
       validate_table_lists(tables, exclude_tables, schema)
 
-      if !tables.empty?
-        tables
-      else
+      if tables.empty?
         all_tables = list_all_tables(schema: schema, conn_string: conn_string)
         all_tables - (exclude_tables + %w[spatial_ref_sys])
+      else
+        tables
       end
     end
 

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -79,9 +79,9 @@ module PgEasyReplicate
       tables = list&.split(",") || []
       exclude_tables = exclude_list&.split(",") || []
 
-      if tables.any? && exclude_tables.any?
+      if !tables.empty? && !exclude_tables.empty?
         abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-      elsif tables.any?
+      elsif !tables.empty?
         tables
       else
         all_tables = list_all_tables(schema: schema, conn_string: conn_string) - %w[spatial_ref_sys]

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -106,25 +106,24 @@ module PgEasyReplicate
         .map(&:values)
         .flatten
     end
-  end
 
-  def convert_to_array(input)
-    input.is_a?(Array) ? input : input&.split(",") || []
-  end
+    def convert_to_array(input)
+      input.is_a?(Array) ? input : input&.split(",") || []
+    end
 
-  def validate_table_lists(tables, exclude_tables, schema_name)
-    table_list = convert_to_array(tables)
-    exclude_table_list = convert_to_array(exclude_tables)
+    def validate_table_lists(tables, exclude_tables, schema_name)
+      table_list = convert_to_array(tables)
+      exclude_table_list = convert_to_array(exclude_tables)
 
-    if !table_list.empty? && !exclude_table_list.empty?
-      abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
-    elsif !table_list.empty?
-      if table_list.size > 0 && (schema_name.nil? || schema_name == "")
-        abort_with("Schema name is required if tables are passed")
+      if !table_list.empty? && !exclude_table_list.empty?
+        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
+      elsif !table_list.empty?
+        if table_list.size > 0 && (schema_name.nil? || schema_name == "")
+          abort_with("Schema name is required if tables are passed")
+        end
+      elsif exclude_table_list.size > 0 && (schema_name.nil? || schema_name == "")
+        abort_with("Schema name is required if exclude tables are passed")
       end
-    elsif exclude_table_list.size > 0 && (schema_name.nil? || schema_name == "")
-      abort_with("Schema name is required if exclude tables are passed")
     end
   end
-end
 end

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -76,8 +76,8 @@ module PgEasyReplicate
     def determine_tables(conn_string:, list: "", exclude_list: "", schema: nil)
       schema ||= "public"
 
-      tables = list&.split(",") || []
-      exclude_tables = exclude_list&.split(",") || []
+      tables = list.is_a?(Array) ? list : list&.split(",") || []
+      exclude_tables = exclude_list.is_a?(Array) ? exclude_list : exclude_list&.split(",") || []
 
       if !tables.empty? && !exclude_tables.empty?
         abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")

--- a/lib/pg_easy_replicate/helper.rb
+++ b/lib/pg_easy_replicate/helper.rb
@@ -73,14 +73,19 @@ module PgEasyReplicate
       abort(msg)
     end
 
-    def determine_tables(conn_string:, list: "", schema: nil)
+    def determine_tables(conn_string:, list: "", exclude_list: "", schema: nil)
       schema ||= "public"
 
       tables = list&.split(",") || []
-      if tables.size > 0
+      exclude_tables = exclude_list&.split(",") || []
+
+      if tables.any? && exclude_tables.any?
+        abort_with("Options --tables(-t) and --exclude-tables(-e) cannot be used together.")
+      elsif tables.any?
         tables
       else
-        list_all_tables(schema: schema, conn_string: conn_string) - %w[ spatial_ref_sys ]
+        all_tables = list_all_tables(schema: schema, conn_string: conn_string) - %w[spatial_ref_sys]
+        all_tables - exclude_tables
       end
     end
 

--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -15,6 +15,7 @@ module PgEasyReplicate
             schema: schema_name,
             conn_string: source_db_url,
             list: options[:tables],
+            exclude_list: options[:exclude_tables]
           )
 
         if options[:recreate_indices_post_copy]

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -698,7 +698,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       teardown_tables
     end
 
-    it "successfully excludes specific tables from replication" do
+    it "successfully excludes specific tables for replication" do
       ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
       described_class.start_sync(
         group_name: "cluster1",
@@ -712,6 +712,19 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       )
       expect(PgEasyReplicate::Group.find("cluster1")).not_to include(
         table_names: "items"
+      )
+    end
+
+    it "successfully includes tables for replication if exclude_tables is not set" do
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      described_class.start_sync(
+        group_name: "cluster1",
+        schema_name: test_schema,
+        recreate_indices_post_copy: true,
+      )
+
+      expect(PgEasyReplicate::Group.find("cluster1")).to include(
+        table_names: "items,sellers",
       )
     end
   end

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -713,6 +713,15 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       expect(PgEasyReplicate::Group.find("cluster1")).not_to include(
         table_names: "items"
       )
+
+      tables = described_class.determine_tables(
+        schema: test_schema,
+        conn_string: connection_url,
+        exclude_list: ["items"],
+      )
+
+      expect(tables).to include("sellers")
+      expect(tables).not_to include("items")
     end
 
     it "successfully includes tables for replication if exclude_tables is not set" do
@@ -726,6 +735,12 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       expect(PgEasyReplicate::Group.find("cluster1")).to include(
         table_names: "items,sellers",
       )
+
+      tables = described_class.determine_tables(
+        schema: test_schema,
+        conn_string: connection_url,
+      )
+      expect(tables).to eq(["items", "sellers"])
     end
   end
 end

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -682,7 +682,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
     end
   end
   
-  describe ".exclude_tables" do
+  describe "excluding tables" do
     before do
       setup_tables
       PgEasyReplicate.bootstrap({ group_name: "cluster1" })

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -740,7 +740,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         schema: test_schema,
         conn_string: connection_url,
       )
-      expect(tables).to eq(%w(items sellers))
+      expect(tables).to eq(%w[items sellers])
     end
   end
 end

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -740,7 +740,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         schema: test_schema,
         conn_string: connection_url,
       )
-      expect(tables).to eq(["items", "sellers"])
+      expect(tables).to eq(%w(items sellers))
     end
   end
 end

--- a/spec/pg_easy_replicate_spec.rb
+++ b/spec/pg_easy_replicate_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe(PgEasyReplicate) do
             { name: "max_replication_slots", setting: "10" },
             { name: "max_wal_senders", setting: "10" },
             { name: "max_worker_processes", setting: "8" },
-            { name: "wal_level", setting: "replica" },
+            { name: "wal_level", setting: "logical" },
           ],
           tables_have_replica_identity: true,
           target_db: [

--- a/spec/pg_easy_replicate_spec.rb
+++ b/spec/pg_easy_replicate_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe(PgEasyReplicate) do
       end
     end
 
-    describe ".exclude_tables" do
+    describe ".excluding tables" do
       before { setup_tables }
     
       after { teardown_tables }

--- a/spec/pg_easy_replicate_spec.rb
+++ b/spec/pg_easy_replicate_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe(PgEasyReplicate) do
             { name: "max_replication_slots", setting: "10" },
             { name: "max_wal_senders", setting: "10" },
             { name: "max_worker_processes", setting: "8" },
-            { name: "wal_level", setting: "logical" },
+            { name: "wal_level", setting: "replica" },
           ],
           tables_have_replica_identity: true,
           target_db: [
@@ -36,7 +36,7 @@ RSpec.describe(PgEasyReplicate) do
       )
     end
 
-    describe ".assert_confg" do
+    describe ".assert_config" do
       let(:source_db_config_without_logical) do
         {
           source_db: [{ name: "wal_level", setting: "replication" }],
@@ -413,5 +413,33 @@ RSpec.describe(PgEasyReplicate) do
         )
       end
     end
+
+    describe ".exclude_tables" do
+      before { setup_tables }
+    
+      after { teardown_tables }
+
+      tables = "items"
+    
+      it "returns error if tables and exclude_tables specified tables are both specified" do
+        expect { described_class.config(tables: tables, exclude_tables: tables, schema_name: test_schema) }.to raise_error(RuntimeError)
+        expect { described_class.assert_config(tables: tables, exclude_tables: tables, schema_name: test_schema) }.to raise_error(RuntimeError)
+      end
+
+      it "doesnt return error if only exclude_tables specified tables are both specified" do
+        allow(described_class).to receive(:config).and_return(
+          {
+            source_db_is_super_user: true,
+            target_db_is_super_user: true,
+            target_db: [{ name: "wal_level", setting: "logical" }],
+            source_db: [{ name: "wal_level", setting: "logical" }],
+            tables_have_replica_identity: true,
+          },
+        )
+        expect { described_class.config(exclude_tables: tables, schema_name: test_schema) }.not_to raise_error
+        expect { described_class.assert_config(exclude_tables: tables, schema_name: test_schema) }.not_to raise_error
+      end
+    end
+    
   end
 end


### PR DESCRIPTION
Proposal to add `exclude_tables` which does the opposite of the cmd `--tables, -t` in that it excludes comma separated table names from the replication sync if specified.

PR adds the following:
- cli integration using `--exclude_tables` / `--e`
- Logic to handle removal of specified table names from sync 
- Validation to abort if `--tables` and `--exclude_tables` are specified together
- Test coverage for `exclude_tables`