### PR TITLE
Support DDL Tracking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
         run: bundle exec rubocop
       # - name: Setup upterm session
       #   uses: lhotari/action-upterm@v1
-      - name: "Setug PG databases"
+      - name: "Setup PG databases"
         run: |
           set -euvxo pipefail
 
@@ -91,6 +91,17 @@ jobs:
 
           psql -h localhost -d postgres-db -U james-bond -p 5432 -c 'show wal_level;'
           psql -h localhost -d postgres-db -U james-bond -p 5433 -c 'show wal_level;'
+
+          sudo -u postgres psql -p 5432 -c "ALTER SYSTEM SET max_connections = '500';"
+          sudo -u postgres psql -p 5433 -c "ALTER SYSTEM SET max_connections = '500';"
+
+          sudo systemctl restart postgresql@${{ matrix.pg.from }}-main.service
+          sudo systemctl restart postgresql@${{ matrix.pg.to }}-main.service
+          sudo systemctl restart postgresql
+
+          # Verify the changes
+          psql -h localhost -d postgres-db -U james-bond -p 5432 -c 'SHOW max_connections;'
+          psql -h localhost -d postgres-db -U james-bond -p 5433 -c 'SHOW max_connections;'
 
       - name: Run RSpec
         run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     pg_easy_replicate (0.2.7)
       ougai (~> 2.0.0)
       pg (~> 1.5.3)
+      pg_query (~> 5.1.0)
       sequel (>= 5.69, < 5.83)
       thor (>= 1.2.2, < 1.4.0)
 
@@ -14,6 +15,12 @@ GEM
     bigdecimal (3.1.8)
     coderay (1.1.3)
     diff-lcs (1.5.1)
+    google-protobuf (4.28.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.0-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
     haml (6.1.1)
       temple (>= 0.8.2)
       thor
@@ -29,6 +36,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
+    pg_query (5.1.0)
+      google-protobuf (>= 3.22.3)
     prettier_print (1.2.1)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       POSTGRES_PASSWORD: james-bond123@7!'3aaR
       POSTGRES_DB: postgres-db
     command: >
+      -c max_connections=200
       -c wal_level=logical
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
@@ -25,6 +26,7 @@ services:
       POSTGRES_PASSWORD: james-bond123@7!'3aaR
       POSTGRES_DB: postgres-db
     command: >
+      -c max_connections=200
       -c wal_level=logical
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/lib/pg_easy_replicate.rb
+++ b/lib/pg_easy_replicate.rb
@@ -6,6 +6,7 @@ require "pg"
 require "sequel"
 require "open3"
 require "English"
+require "pg_query"
 
 require "pg_easy_replicate/helper"
 require "pg_easy_replicate/version"
@@ -15,6 +16,8 @@ require "pg_easy_replicate/orchestrate"
 require "pg_easy_replicate/stats"
 require "pg_easy_replicate/group"
 require "pg_easy_replicate/cli"
+require "pg_easy_replicate/ddl_audit"
+require "pg_easy_replicate/ddl_manager"
 
 Sequel.default_timezone = :utc
 module PgEasyReplicate
@@ -199,6 +202,14 @@ module PgEasyReplicate
           if options[:everything]
             logger.info("Dropping replication user on target database")
             drop_user(conn_string: target_db_url)
+          end
+          -> do
+            if options[:everything]
+              PgEasyReplicate::DDLManager.cleanup_ddl_tracking(
+                conn_string: source_db_url,
+                group_name: options[:group_name],
+              )
+            end
           end
         end,
       ]

--- a/lib/pg_easy_replicate/ddl_audit.rb
+++ b/lib/pg_easy_replicate/ddl_audit.rb
@@ -1,0 +1,256 @@
+# frozen_string_literal: true
+
+require "pg_query"
+
+module PgEasyReplicate
+  class DDLAudit
+    extend Helper
+
+    class << self
+      def setup(group_name)
+        conn = connect_to_internal_schema
+        return if conn.table_exists?(table_name)
+
+        begin
+          conn.create_table(table_name) do
+            primary_key(:id)
+            String(:group_name, null: false)
+            String(:event_type, null: false)
+            String(:object_type)
+            String(:object_identity)
+            String(:ddl_command, text: true)
+            DateTime(:created_at, default: Sequel::CURRENT_TIMESTAMP)
+          end
+
+          create_trigger_function(conn, group_name)
+          create_event_triggers(conn, group_name)
+        rescue => e
+          abort_with("Failed to set up DDL audit: #{e.message}")
+        ensure
+          conn&.disconnect
+        end
+      end
+
+      def create(
+        group_name,
+        event_type,
+        object_type,
+        object_identity,
+        ddl_command
+      )
+        conn = connect_to_internal_schema
+        begin
+          conn[table_name].insert(
+            group_name: group_name,
+            event_type: event_type,
+            object_type: object_type,
+            object_identity: object_identity,
+            ddl_command: ddl_command,
+            created_at: Time.now.utc,
+          )
+        rescue => e
+          abort_with("Adding DDL audit entry failed: #{e.message}")
+        ensure
+          conn&.disconnect
+        end
+      end
+
+      def list_changes(group_name, limit: 100)
+        conn = connect_to_internal_schema
+        begin
+          conn[table_name]
+            .where(group_name: group_name)
+            .order(Sequel.desc(:id))
+            .limit(limit)
+            .all
+        rescue => e
+          abort_with("Listing DDL changes failed: #{e.message}")
+        ensure
+          conn&.disconnect
+        end
+      end
+
+      def apply_change(source_conn_string, target_conn_string, group_name, id)
+        ddl_queries = fetch_ddl_query(source_conn_string, group_name, id: id)
+        apply_ddl_changes(target_conn_string, ddl_queries)
+      end
+
+      def apply_all_changes(source_conn_string, target_conn_string, group_name)
+        ddl_queries = fetch_ddl_query(source_conn_string, group_name)
+        apply_ddl_changes(target_conn_string, ddl_queries)
+      end
+
+      def drop(group_name)
+        conn = connect_to_internal_schema
+        begin
+          drop_event_triggers(conn, group_name)
+          drop_trigger_function(conn, group_name)
+          conn[table_name].where(group_name: group_name).delete
+        rescue => e
+          abort_with("Dropping DDL audit failed: #{e.message}")
+        ensure
+          conn&.disconnect
+        end
+      end
+
+      private
+
+      def table_name
+        :pger_ddl_audits
+      end
+
+      def connect_to_internal_schema(conn_string = nil)
+        Query.connect(
+          connection_url: conn_string || source_db_url,
+          schema: internal_schema_name,
+        )
+      end
+
+      def create_trigger_function(conn, group_name)
+        group = PgEasyReplicate::Group.find(group_name)
+        tables = group[:table_names].split(",").map(&:strip)
+        schema_name = group[:schema_name]
+        sanitized_group_name = sanitize_identifier(group_name)
+
+        full_table_names = tables.map { |table| "#{schema_name}.#{table}" }
+        puts "full_table_names: #{full_table_names}"
+        conn.run(<<~SQL)
+          CREATE OR REPLACE FUNCTION #{internal_schema_name}.pger_ddl_trigger_#{sanitized_group_name}() RETURNS event_trigger AS $$
+          DECLARE
+            obj record;
+            ddl_command text;
+            affected_table text;
+          BEGIN
+            SELECT current_query() INTO ddl_command;
+
+            IF TG_EVENT = 'ddl_command_end' THEN
+              FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands()
+              LOOP
+                IF obj.object_type = 'table' AND obj.object_identity = ANY(ARRAY['#{full_table_names.join("','")}']) THEN
+                  INSERT INTO #{internal_schema_name}.#{table_name} (group_name, event_type, object_type, object_identity, ddl_command)
+                  VALUES ('#{group_name}', TG_EVENT, obj.object_type, obj.object_identity, ddl_command);
+                ELSIF obj.object_type = 'index' THEN
+                  SELECT (regexp_match(ddl_command, 'ON\\s+(\\S+)'))[1] INTO affected_table;
+                  IF affected_table = ANY(ARRAY['#{full_table_names.join("','")}']) THEN
+                    INSERT INTO #{internal_schema_name}.#{table_name} (group_name, event_type, object_type, object_identity, ddl_command)
+                    VALUES ('#{group_name}', TG_EVENT, obj.object_type, obj.object_identity, ddl_command);
+                  END IF;
+                END IF;
+              END LOOP;
+            ELSIF TG_EVENT = 'sql_drop' THEN
+              FOR obj IN SELECT * FROM pg_event_trigger_dropped_objects()
+              LOOP
+                IF obj.object_type IN ('table', 'index') AND
+                   (obj.object_identity = ANY(ARRAY['#{full_table_names.join("','")}']) OR
+                    obj.object_identity ~ ('^' || '#{schema_name}' || '\\.(.*?)_.*$'))
+                THEN
+                  INSERT INTO #{internal_schema_name}.#{table_name} (group_name, event_type, object_type, object_identity, ddl_command)
+                  VALUES ('#{group_name}', TG_EVENT, obj.object_type, obj.object_identity, ddl_command);
+                END IF;
+              END LOOP;
+            ELSIF TG_EVENT = 'table_rewrite' THEN
+              FOR obj IN SELECT * FROM pg_event_trigger_table_rewrite_oid()
+              LOOP
+                IF obj.oid::regclass::text = ANY(ARRAY['#{full_table_names.join("','")}']) THEN
+                  INSERT INTO #{internal_schema_name}.#{table_name} (group_name, event_type, object_type, object_identity, ddl_command)
+                  VALUES ('#{group_name}', TG_EVENT, 'table', obj.oid::regclass::text, ddl_command);
+                END IF;
+              END LOOP;
+            END IF;
+          END;
+          $$ LANGUAGE plpgsql;
+        SQL
+      rescue => e
+        abort_with("Creating DDL trigger function failed: #{e.message}")
+      end
+
+      def create_event_triggers(conn, group_name)
+        sanitized_group_name = sanitize_identifier(group_name)
+        conn.run(<<~SQL)
+          DROP EVENT TRIGGER IF EXISTS pger_ddl_trigger_#{sanitized_group_name};
+          CREATE EVENT TRIGGER pger_ddl_trigger_#{sanitized_group_name} ON ddl_command_end
+          EXECUTE FUNCTION #{internal_schema_name}.pger_ddl_trigger_#{sanitized_group_name}();
+
+          DROP EVENT TRIGGER IF EXISTS pger_drop_trigger_#{sanitized_group_name};
+          CREATE EVENT TRIGGER pger_drop_trigger_#{sanitized_group_name} ON sql_drop
+          EXECUTE FUNCTION #{internal_schema_name}.pger_ddl_trigger_#{sanitized_group_name}();
+
+          DROP EVENT TRIGGER IF EXISTS pger_table_rewrite_trigger_#{sanitized_group_name};
+          CREATE EVENT TRIGGER pger_table_rewrite_trigger_#{sanitized_group_name} ON table_rewrite
+          EXECUTE FUNCTION #{internal_schema_name}.pger_ddl_trigger_#{sanitized_group_name}();
+        SQL
+      rescue => e
+        abort_with("Creating event triggers failed: #{e.message}")
+      end
+
+      def drop_event_triggers(conn, group_name)
+        sanitized_group_name = sanitize_identifier(group_name)
+        conn.run(<<~SQL)
+          DROP EVENT TRIGGER IF EXISTS pger_ddl_trigger_#{sanitized_group_name};
+          DROP EVENT TRIGGER IF EXISTS pger_drop_trigger_#{sanitized_group_name};
+          DROP EVENT TRIGGER IF EXISTS pger_table_rewrite_trigger_#{sanitized_group_name};
+        SQL
+      rescue => e
+        abort_with("Dropping event triggers failed: #{e.message}")
+      end
+
+      def drop_trigger_function(conn, group_name)
+        sanitized_group_name = sanitize_identifier(group_name)
+        conn.run(
+          "DROP FUNCTION IF EXISTS #{internal_schema_name}.pger_ddl_trigger_#{sanitized_group_name}();",
+        )
+      rescue => e
+        abort_with("Dropping trigger function failed: #{e.message}")
+      end
+
+      def self.extract_table_info(sql)
+        parsed = PgQuery.parse(sql)
+        stmt = parsed.tree.stmts.first.stmt
+
+        case stmt
+        when PgQuery::CreateStmt, PgQuery::IndexStmt, PgQuery::AlterTableStmt
+          schema_name = stmt.relation.schemaname || "public"
+          table_name = stmt.relation.relname
+          "#{schema_name}.#{table_name}"
+        end
+      rescue PgQuery::ParseError
+        nil
+      end
+
+      def sanitize_identifier(identifier)
+        identifier.gsub(/[^a-zA-Z0-9_]/, "_")
+      end
+
+      def fetch_ddl_query(source_conn_string, group_name, id: nil)
+        source_conn = connect_to_internal_schema(source_conn_string)
+        begin
+          query = source_conn[table_name].where(group_name: group_name)
+          query = query.where(id: id) if id
+          result = query.order(:id).select_map(:ddl_command)
+          result.uniq
+        rescue => e
+          abort_with("Fetching DDL queries failed: #{e.message}")
+        ensure
+          source_conn&.disconnect
+        end
+      end
+
+      def apply_ddl_changes(target_conn_string, ddl_queries)
+        target_conn = Query.connect(connection_url: target_conn_string)
+        begin
+          ddl_queries.each do |query|
+            target_conn.run(query)
+          rescue => e
+            abort_with(
+              "Error executing DDL command: #{query}. Error: #{e.message}",
+            )
+          end
+        rescue => e
+          abort_with("Applying DDL changes failed: #{e.message}")
+        ensure
+          target_conn&.disconnect
+        end
+      end
+    end
+  end
+end

--- a/lib/pg_easy_replicate/ddl_manager.rb
+++ b/lib/pg_easy_replicate/ddl_manager.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module PgEasyReplicate
+  module DDLManager
+    extend Helper
+
+    class << self
+      def setup_ddl_tracking(
+        group_name:, conn_string: source_db_url,
+        schema: "public"
+      )
+        DDLAudit.setup(group_name)
+      end
+
+      def cleanup_ddl_tracking(
+        group_name:, conn_string: source_db_url,
+        schema: "public"
+      )
+        DDLAudit.drop(group_name)
+      end
+
+      def list_ddl_changes(
+        group_name:, conn_string: source_db_url,
+        schema: "public",
+        limit: 100
+      )
+        DDLAudit.list_changes(group_name, limit: limit)
+      end
+
+      def apply_ddl_change(
+        group_name:, id:, source_conn_string: source_db_url,
+        target_conn_string: target_db_url,
+        schema: "public"
+      )
+        DDLAudit.apply_change(
+          source_conn_string,
+          target_conn_string,
+          group_name,
+          id,
+        )
+      end
+
+      def apply_all_ddl_changes(
+        group_name:, source_conn_string: source_db_url,
+        target_conn_string: target_db_url,
+        schema: "public"
+      )
+        DDLAudit.apply_all_changes(
+          source_conn_string,
+          target_conn_string,
+          group_name,
+        )
+      end
+    end
+  end
+end

--- a/pg_easy_replicate.gemspec
+++ b/pg_easy_replicate.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("ougai", "~> 2.0.0")
   spec.add_runtime_dependency("pg", "~> 1.5.3")
+  spec.add_runtime_dependency("pg_query", "~> 5.1.0")
   spec.add_runtime_dependency("sequel", ">= 5.69", "< 5.83")
   spec.add_runtime_dependency("thor", ">= 1.2.2", "< 1.4.0")
 

--- a/scripts/e2e-start.sh
+++ b/scripts/e2e-start.sh
@@ -10,9 +10,17 @@ export SOURCE_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhos
 export TARGET_DB_URL="postgres://james-bond:james-bond123%407%21%273aaR@localhost:5433/postgres-db"
 export PGPASSWORD='james-bond123@7!'"'"''"'"'3aaR'
 
-# Config check, Bootstrap and cleanup
 echo "===== Performing Bootstrap and cleanup"
 bundle exec bin/pg_easy_replicate bootstrap -g cluster-1 --copy-schema
-bundle exec bin/pg_easy_replicate start_sync -g cluster-1 -s public --recreate-indices-post-copy
+bundle exec bin/pg_easy_replicate start_sync -g cluster-1 -s public --recreate-indices-post-copy --track-ddl
 bundle exec bin/pg_easy_replicate stats -g cluster-1
+
+echo "===== Applying DDL change"
+psql $SOURCE_DB_URL -c "ALTER TABLE public.pgbench_accounts ADD COLUMN test_column VARCHAR(255)"
+
+echo "===== Applying DDL changes"
+echo "Y" | bundle exec bin/pg_easy_replicate apply_ddl_change -g cluster-1
+
+# Switchover
+echo "===== Performing switchover"
 bundle exec bin/pg_easy_replicate switchover -g cluster-1

--- a/spec/pg_easy_replicate/ddl_audit_spec.rb
+++ b/spec/pg_easy_replicate/ddl_audit_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+RSpec.describe(PgEasyReplicate::DDLAudit) do
+  let(:schema_name) { "pger_test" }
+  let(:group_name) { "cluster1" }
+
+  before do
+    setup_tables
+    PgEasyReplicate.bootstrap({ group_name: group_name })
+    PgEasyReplicate::Group.create(
+      name: group_name,
+      table_names: "sellers,items",
+      schema_name: schema_name,
+      started_at: Time.now.utc,
+    )
+  end
+
+  after do
+    teardown_tables
+    PgEasyReplicate.cleanup({ everything: true })
+  end
+
+  describe ".setup" do
+    it "creates the DDL audit table and triggers" do
+      described_class.setup(group_name)
+
+      trigger_status =
+        PgEasyReplicate::Query.run(
+          query:
+            "SELECT evtenabled FROM pg_event_trigger WHERE evtname = 'pger_ddl_trigger_#{group_name}'",
+          connection_url: connection_url,
+        ).first
+      puts "Debug: Trigger status - #{trigger_status.inspect}"
+
+      table_exists =
+        ddl_audit_table_exists?(nil, described_class.send(:table_name))
+      expect(table_exists).to be(true)
+
+      trigger_function_exists =
+        function_exists?("pger_ddl_trigger_#{group_name}")
+      expect(trigger_function_exists).to be(true)
+
+      event_triggers_exist = event_triggers_exist?(group_name)
+      expect(event_triggers_exist).to be(true)
+    end
+
+    it "doesn't create the table if it already exists" do
+      described_class.setup(group_name)
+      expect { described_class.setup(group_name) }.not_to raise_error
+      expect(table_exists?(described_class.send(:table_name))).to be(true)
+    end
+  end
+
+  describe ".drop" do
+    before { described_class.setup(group_name) }
+
+    it "drops the DDL audit table, triggers, and function" do
+      described_class.drop(group_name)
+
+      table_exists = table_exists?(described_class.send(:table_name))
+      expect(table_exists).to be(true) # Table should still exist, only group-specific data is deleted
+
+      trigger_function_exists =
+        function_exists?("pger_ddl_trigger_#{group_name}")
+      expect(trigger_function_exists).to be(false)
+
+      event_triggers_exist = event_triggers_exist?(group_name)
+      expect(event_triggers_exist).to be(false)
+    end
+  end
+
+  describe "DDL change capture" do
+    before { described_class.setup(group_name) }
+
+    it "captures ALTER TABLE DDL for tables in the group" do
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.sellers ADD COLUMN test_column VARCHAR(255)",
+      )
+
+      changes = described_class.list_changes(group_name)
+      expect(changes.size).to eq(1)
+      expect(changes.first[:event_type]).to eq("ddl_command_end")
+      expect(changes.first[:object_type]).to eq("table")
+      expect(changes.first[:object_identity]).to eq("#{schema_name}.sellers")
+      expect(changes.first[:ddl_command]).to include("ALTER TABLE")
+      expect(changes.first[:ddl_command]).to include("ADD COLUMN test_column")
+    end
+
+    it "captures CREATE INDEX DDL for tables in the group" do
+      execute_ddl(
+        "CREATE INDEX idx_sellers_name ON #{schema_name}.sellers (name)",
+      )
+
+      changes = described_class.list_changes(group_name)
+      expect(changes.size).to eq(1)
+      expect(changes.first[:event_type]).to eq("ddl_command_end")
+      expect(changes.first[:object_type]).to eq("index")
+      expect(changes.first[:object_identity]).to eq(
+        "#{schema_name}.idx_sellers_name",
+      )
+      expect(changes.first[:ddl_command]).to include("CREATE INDEX")
+      expect(changes.first[:ddl_command]).to include(
+        "ON #{schema_name}.sellers",
+      )
+    end
+
+    it "does not capture DDL for tables not in the group" do
+      execute_ddl(
+        "CREATE TABLE #{schema_name}.not_in_group (id serial PRIMARY KEY)",
+      )
+
+      described_class.list_changes(group_name)
+
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.not_in_group ADD COLUMN test_column VARCHAR(255)",
+      )
+
+      changes = described_class.list_changes(group_name)
+      expect(changes.size).to eq(0)
+
+      execute_ddl("DROP TABLE #{schema_name}.not_in_group")
+    end
+
+    it "captures CREATE and DROP INDEX DDL for tables in the group" do
+      execute_ddl(
+        "CREATE INDEX idx_sellers_name ON #{schema_name}.sellers (name)",
+      )
+
+      execute_ddl("DROP INDEX #{schema_name}.idx_sellers_name")
+
+      changes = described_class.list_changes(group_name)
+      expect(changes.size).to eq(2)
+
+      create_index_change =
+        changes.find { |c| c[:ddl_command].include?("CREATE INDEX") }
+      drop_index_change =
+        changes.find { |c| c[:ddl_command].include?("DROP INDEX") }
+
+      expect(create_index_change).not_to be_nil
+      expect(create_index_change[:event_type]).to eq("ddl_command_end")
+      expect(create_index_change[:object_type]).to eq("index")
+      expect(create_index_change[:object_identity]).to eq(
+        "#{schema_name}.idx_sellers_name",
+      )
+      expect(create_index_change[:ddl_command]).to include("CREATE INDEX")
+      expect(create_index_change[:ddl_command]).to include(
+        "ON #{schema_name}.sellers",
+      )
+
+      expect(drop_index_change).not_to be_nil
+      expect(drop_index_change[:event_type]).to eq("sql_drop")
+      expect(drop_index_change[:object_type]).to eq("index")
+      expect(drop_index_change[:object_identity]).to eq(
+        "#{schema_name}.idx_sellers_name",
+      )
+      expect(drop_index_change[:ddl_command]).to include("DROP INDEX")
+    end
+  end
+
+  describe ".list_changes" do
+    before do
+      described_class.setup(group_name)
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.sellers ADD COLUMN email VARCHAR(255)",
+      )
+    end
+
+    it "lists DDL changes for the specific group" do
+      changes = described_class.list_changes(group_name)
+
+      expect(changes.size).to eq(1)
+      expect(changes.first.keys).to match_array(
+        %i[
+          id
+          group_name
+          created_at
+          event_type
+          object_type
+          object_identity
+          ddl_command
+        ],
+      )
+      expect(changes.first[:group_name]).to eq(group_name)
+      expect(changes.first[:event_type]).to eq("ddl_command_end")
+      expect(changes.first[:object_type]).to eq("table")
+      expect(changes.first[:object_identity]).to include("sellers")
+      expect(changes.first[:ddl_command]).to include("ALTER TABLE")
+      expect(changes.first[:ddl_command]).to include("ADD COLUMN email")
+    end
+  end
+
+  describe ".apply_change" do
+    before { described_class.setup(group_name) }
+
+    it "applies ALTER TABLE DDL change to the target database" do
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.sellers ADD COLUMN email VARCHAR(255)",
+      )
+      change_id = described_class.list_changes(group_name).first[:id]
+
+      described_class.apply_change(
+        connection_url,
+        target_connection_url,
+        group_name,
+        change_id,
+      )
+
+      column_exists =
+        column_exists?(target_connection_url, schema_name, "sellers", "email")
+      expect(column_exists).to be(true)
+    end
+  end
+
+  describe ".apply_all_changes" do
+    before { described_class.setup(group_name) }
+
+    it "applies all DDL changes for the specific group to the target database" do
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.sellers ADD COLUMN email VARCHAR(255)",
+      )
+      execute_ddl(
+        "ALTER TABLE #{schema_name}.items ADD COLUMN description TEXT",
+      )
+      execute_ddl(
+        "CREATE TABLE #{schema_name}.not_in_group (id serial PRIMARY KEY)",
+      ) # This should not be applied
+
+      described_class.apply_all_changes(
+        connection_url,
+        target_connection_url,
+        group_name,
+      )
+
+      sellers_column_exists =
+        column_exists?(target_connection_url, schema_name, "sellers", "email")
+      items_column_exists =
+        column_exists?(
+          target_connection_url,
+          schema_name,
+          "items",
+          "description",
+        )
+      not_in_group_exists =
+        table_exists_in_schema?(
+          target_connection_url,
+          schema_name,
+          "not_in_group",
+        )
+
+      expect(sellers_column_exists).to be(true)
+      expect(items_column_exists).to be(true)
+      expect(not_in_group_exists).to be(false)
+    end
+  end
+end

--- a/spec/pg_easy_replicate/ddl_manager_spec.rb
+++ b/spec/pg_easy_replicate/ddl_manager_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe(PgEasyReplicate::DDLManager) do
+  let(:group_name) { "test_group" }
+  let(:schema_name) { "public" }
+  let(:conn_string) { "postgres://user:password@localhost:5432/testdb" }
+  let(:source_conn_string) do
+    "postgres://user:password@localhost:5432/sourcedb"
+  end
+  let(:target_conn_string) do
+    "postgres://user:password@localhost:5432/targetdb"
+  end
+
+  describe ".setup_ddl_tracking" do
+    it "calls DDLAudit.setup with the correct parameters" do
+      expect(PgEasyReplicate::DDLAudit).to receive(:setup).with(group_name)
+
+      described_class.setup_ddl_tracking(
+        conn_string: conn_string,
+        group_name: group_name,
+        schema: schema_name,
+      )
+    end
+  end
+
+  describe ".cleanup_ddl_tracking" do
+    it "calls DDLAudit.drop with the correct parameters" do
+      expect(PgEasyReplicate::DDLAudit).to receive(:drop).with(group_name)
+
+      described_class.cleanup_ddl_tracking(
+        conn_string: conn_string,
+        group_name: group_name,
+        schema: schema_name,
+      )
+    end
+  end
+
+  describe ".list_ddl_changes" do
+    it "calls DDLAudit.list_changes with the correct parameters" do
+      limit = 50
+      expect(PgEasyReplicate::DDLAudit).to receive(:list_changes).with(
+        group_name,
+        limit: limit,
+      )
+
+      described_class.list_ddl_changes(
+        conn_string: conn_string,
+        group_name: group_name,
+        schema: schema_name,
+        limit: limit,
+      )
+    end
+  end
+
+  describe ".apply_ddl_change" do
+    it "calls DDLAudit.apply_change with the correct parameters" do
+      id = 1
+      expect(PgEasyReplicate::DDLAudit).to receive(:apply_change).with(
+        source_conn_string,
+        target_conn_string,
+        group_name,
+        id,
+      )
+
+      described_class.apply_ddl_change(
+        source_conn_string: source_conn_string,
+        target_conn_string: target_conn_string,
+        group_name: group_name,
+        id: id,
+        schema: schema_name,
+      )
+    end
+  end
+
+  describe ".apply_all_ddl_changes" do
+    it "calls DDLAudit.apply_all_changes with the correct parameters" do
+      expect(PgEasyReplicate::DDLAudit).to receive(:apply_all_changes).with(
+        source_conn_string,
+        target_conn_string,
+        group_name,
+      )
+
+      described_class.apply_all_ddl_changes(
+        source_conn_string: source_conn_string,
+        target_conn_string: target_conn_string,
+        group_name: group_name,
+        schema: schema_name,
+      )
+    end
+  end
+end

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       teardown_tables
     end
 
-    it "succesfully" do
+    it "successfully" do
       ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
       described_class.start_sync(
         group_name: "cluster1",
@@ -273,7 +273,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       )
     end
 
-    it "fails succesfully" do
+    it "fails successfully" do
       allow(PgEasyReplicate::Orchestrate).to receive(
         :create_subscription,
       ).and_raise("boo")
@@ -291,17 +291,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
 
       expect(pg_subscriptions(connection_url: target_connection_url)).to eq([])
 
-      expect(PgEasyReplicate::Group.find("cluster1")).to include(
-        switchover_completed_at: nil,
-        created_at: kind_of(Time),
-        name: "cluster1",
-        schema_name: "pger_test",
-        id: kind_of(Integer),
-        started_at: kind_of(Time),
-        updated_at: kind_of(Time),
-        failed_at: kind_of(Time),
-        table_names: "items,sellers",
-      )
+      expect(PgEasyReplicate::Group.find("cluster1")).to be_nil
     end
   end
 
@@ -328,7 +318,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       teardown_tables
     end
 
-    it "succesfully" do
+    it "successfully" do
       expect(
         vacuum_stats(url: target_connection_url, schema: test_schema),
       ).to include(
@@ -380,7 +370,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
     end
 
-    it "succesfully" do
+    it "successfully" do
       conn1 =
         PgEasyReplicate::Query.connect(
           connection_url: connection_url,
@@ -513,7 +503,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       )
     end
 
-    it "succesfully with no vacuum and analyze" do
+    it "successfully with no vacuum and analyze" do
       conn1 =
         PgEasyReplicate::Query.connect(
           connection_url: connection_url,
@@ -562,7 +552,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       )
     end
 
-    it "succesfully with exclude_tables" do
+    it "successfully with exclude_tables" do
       conn1 =
         PgEasyReplicate::Query.connect(
           connection_url: connection_url,


### PR DESCRIPTION
`pg_easy_replicate` now includes a DDL tracking for most common DDL operations (`ALTER`, `CREATE INDEX`/`DROP INDEX`) allowing users to monitor and apply schema changes between source and target databases during the replication process. `pg_easy_replicate` won't automatically apply the changes (feature request welcome). For now, it exposes the ability to list and apply DDL changes. 


1. DDL Tracking:
   - Enabled with the `--track-ddl` during `start_sync`.
   - Uses PostgreSQL event triggers to capture DDL events (`ALTER`, `CREATE INDEX`/`DROP INDEX`) on specified tables.
   - Stores DDL changes in a dedicated audit table (`pger_ddl_audits`) within an internal schema.

2. Listing DDL Changes:
   - Command: `pg_easy_replicate list_ddl_changes -g <group-name> [-l <limit>]`
   - Displays recent DDL changes in JSON format, including details like ID, event type, object type, and the actual DDL command.

3. Applying DDL Changes:
   - Command: `pg_easy_replicate apply_ddl_change -g <group-name> [-i <change-id>]`
   - Allows applying a specific change (by ID) or all pending changes.
   - Provides an interactive prompt when applying all changes, showing a summary and requesting confirmation.

