### PR TITLE
Proposal: add notify command to send stats results to an endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Battle tested in production at [Tines](https://www.tines.com/) 🚀
     - [Listing DDL Changes](#listing-ddl-changes)
     - [Applying DDL Changes](#applying-ddl-changes)
   - [Stats](#stats)
+  - [Notify](#notify)
   - [Performing switchover](#performing-switchover)
 - [Replicating single database with custom tables](#replicating-single-database-with-custom-tables)
 - [Exclude tables from replication](#exclude-tables-from-replication)
@@ -120,6 +121,7 @@ pg_easy_replicate commands:
   pg_easy_replicate help [COMMAND]                           # Describe available commands or one specific command
   pg_easy_replicate start_sync -g, --group-name=GROUP_NAME   # Starts the logical replication from source database to target database provisioned in the group
   pg_easy_replicate stats  -g, --group-name=GROUP_NAME       # Prints the statistics in JSON for the group
+  pg_easy_replicate notify  -g, --group-name=GROUP_NAME,  -u --url=URL_TO_NOTIFY    # Sends notifications of all stats values for a group to a specified url
   pg_easy_replicate stop_sync -g, --group-name=GROUP_NAME    # Stop the logical replication from source database to target database provisioned in the group
   pg_easy_replicate switchover  -g, --group-name=GROUP_NAME  # Puts the source database in read only mode after all the data is flushed and written
   pg_easy_replicate version                                  # Prints the version
@@ -274,6 +276,16 @@ $ pg_easy_replicate stats --group-name database-cluster-1
   "switchover_completed_at": null
 
   ....
+```
+
+### Notify
+
+You can send stats to an endpoint on an interval using notify. This can be configured to receieve the stats to this url on a frequency (default 10s). A timeout can also be configured for the request to the endpoint (default 10s). This gives you greater control over processing different events in the replication cycle in your workflow.
+
+Once the stats is populated with a value for `switchover_completed_at` the requests will automatically stop sending to the endpoint.
+
+```bash
+$ pg_easy_replicate notify --group-name database-cluster-1 --url https://example.com/webhook --frequency 10 --timeout 10
 ```
 
 ### Performing switchover

--- a/README.md
+++ b/README.md
@@ -282,8 +282,6 @@ $ pg_easy_replicate stats --group-name database-cluster-1
 
 You can send stats to an endpoint on an interval using notify. This can be configured to receieve the stats to this url on a frequency (default 10s). A timeout can also be configured for the request to the endpoint (default 10s). This gives you greater control over processing different events in the replication cycle in your workflow.
 
-Once the stats is populated with a value for `switchover_completed_at` the requests will automatically stop sending to the endpoint.
-
 ```bash
 $ pg_easy_replicate notify --group-name database-cluster-1 --url https://example.com/webhook --frequency 10 --timeout 10
 ```

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -163,7 +163,7 @@ module PgEasyReplicate
       end
     end
 
-    desc "notify", "Sends a notification with replication status to a specified webhook"
+    desc "notify", "Sends a notification with replication status to a specified url"
     method_option :group_name, aliases: "-g", required: true, desc: "Name of the group previously provisioned"
     method_option :url, aliases: "-u", required: true, desc: "URL for notification"
     method_option :frequency, aliases: "-f", type: :numeric, default: 10, desc: "Frequency for sending stats to the endpoint provided"

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -166,10 +166,11 @@ module PgEasyReplicate
     desc "notify", "Sends a notification with replication status to a specified webhook"
     method_option :group_name, aliases: "-g", required: true, desc: "Name of the group previously provisioned"
     method_option :url, aliases: "-u", required: true, desc: "URL for notification"
+    method_option :frequency, aliases: "-f", type: :numeric, default: 10, desc: "Frequency for sending stats to the endpoint provided"
     method_option :timeout, aliases: "-t", type: :numeric, default: 10, desc: "Timeout for the notify request"
 
     def notify
-      PgEasyReplicate::Stats.notify(options[:group_name], options[:url], options[:timeout])
+      PgEasyReplicate::Stats.notify(options[:group_name], options[:url], options[:frequency], options[:timeout])
     end
 
 

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -173,7 +173,6 @@ module PgEasyReplicate
       PgEasyReplicate::Stats.notify(options[:group_name], options[:url], options[:frequency], options[:timeout])
     end
 
-
     desc "list_ddl_changes", "Lists recent DDL changes in the source database"
     method_option :group_name,
                   aliases: "-g",

--- a/lib/pg_easy_replicate/cli.rb
+++ b/lib/pg_easy_replicate/cli.rb
@@ -163,6 +163,16 @@ module PgEasyReplicate
       end
     end
 
+    desc "notify", "Sends a notification with replication status to a specified webhook"
+    method_option :group_name, aliases: "-g", required: true, desc: "Name of the group previously provisioned"
+    method_option :url, aliases: "-u", required: true, desc: "URL for notification"
+    method_option :timeout, aliases: "-t", type: :numeric, default: 10, desc: "Timeout for the notify request"
+
+    def notify
+      PgEasyReplicate::Stats.notify(options[:group_name], options[:url], options[:timeout])
+    end
+
+
     desc "list_ddl_changes", "Lists recent DDL changes in the source database"
     method_option :group_name,
                   aliases: "-g",

--- a/lib/pg_easy_replicate/stats.rb
+++ b/lib/pg_easy_replicate/stats.rb
@@ -59,16 +59,10 @@ module PgEasyReplicate
 
           puts "Notification sent: #{response.code} #{response.message}"
 
-          # Check if switchover has been completed, and if so, exit after this notification
-          if stats[:switchover_completed_at]
-            puts "Switchover completed at #{stats[:switchover_completed_at]}. Stopping notifications."
-            break
-          end
-
           sleep(frequency)
         end
       rescue StandardError => e
-        puts "An error occurred: #{e.message}"
+        abort_with("Notify failed with: #{e.message}")
       end
 
       # Get

--- a/lib/pg_easy_replicate/stats.rb
+++ b/lib/pg_easy_replicate/stats.rb
@@ -39,6 +39,28 @@ module PgEasyReplicate
         end
       end
 
+      def notify(group_name, url, timeout = 10)
+        loop do
+          stats = object(group_name)
+          uri = URI.parse(webhook_url)
+
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == "https")
+
+          request = Net::HTTP::Post.new(uri.request_uri)
+          request.content_type = "application/json"
+          request.body = stats.to_json
+
+          response = http.request(request)
+
+          puts "Notification sent: #{response.code} #{response.message}"
+
+          sleep(timeout)
+        end
+      rescue StandardError => e
+        puts "An error occurred: #{e.message}"
+      end
+
       # Get
       def lag_stats(group_name)
         sql = <<~SQL

--- a/spec/pg_easy_replicate/stats_spec.rb
+++ b/spec/pg_easy_replicate/stats_spec.rb
@@ -1,234 +1,234 @@
 # frozen_string_literal: true
 
 RSpec.describe(PgEasyReplicate::Stats) do
-  describe ".lag_stats" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".lag_stats" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      result = nil
-      count = 0
-      # Wait for sync stats to be up
-      loop do
-        count += 1
-        break if count > 5
-        sleep 1
-        result = described_class.lag_stats("cluster1").first
-      end
+  #   it "successfully" do
+  #     result = nil
+  #     count = 0
+  #     # Wait for sync stats to be up
+  #     loop do
+  #       count += 1
+  #       break if count > 5
+  #       sleep 1
+  #       result = described_class.lag_stats("cluster1").first
+  #     end
 
-      expect(result).to include(
-        application_name: "pger_subscription_cluster1",
-        client_addr: kind_of(String),
-        flush_lag: kind_of(BigDecimal),
-        pid: kind_of(Integer),
-        replay_lag: kind_of(BigDecimal),
-        state: kind_of(String),
-        sync_state: kind_of(String),
-        user_name: "james-bond",
-        write_lag: kind_of(BigDecimal),
-      )
-    end
-  end
+  #     expect(result).to include(
+  #       application_name: "pger_subscription_cluster1",
+  #       client_addr: kind_of(String),
+  #       flush_lag: kind_of(BigDecimal),
+  #       pid: kind_of(Integer),
+  #       replay_lag: kind_of(BigDecimal),
+  #       state: kind_of(String),
+  #       sync_state: kind_of(String),
+  #       user_name: "james-bond",
+  #       write_lag: kind_of(BigDecimal),
+  #     )
+  #   end
+  # end
 
-  describe ".pg_replication_slots" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".pg_replication_slots" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      result = nil
-      count = 0
-      # Wait for sync stats to be up
-      loop do
-        count += 1
-        break if count > 5
-        sleep 1
-        result = described_class.pg_replication_slots("cluster1").first
-      end
+  #   it "successfully" do
+  #     result = nil
+  #     count = 0
+  #     # Wait for sync stats to be up
+  #     loop do
+  #       count += 1
+  #       break if count > 5
+  #       sleep 1
+  #       result = described_class.pg_replication_slots("cluster1").first
+  #     end
 
-      expect(result).to include(
-        slot_name: "pger_subscription_cluster1",
-        slot_type: "logical",
-      )
-    end
-  end
+  #     expect(result).to include(
+  #       slot_name: "pger_subscription_cluster1",
+  #       slot_type: "logical",
+  #     )
+  #   end
+  # end
 
-  describe ".replication_stats" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".replication_stats" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      ENV["TARGET_DB_URL"] = target_connection_url
-      expect(described_class.replication_stats("cluster1")).to include(
-        {
-          replication_state: kind_of(String),
-          subscription_name: "pger_subscription_cluster1",
-          table_name: "items",
-          table_schema: "pger_test",
-        },
-        {
-          replication_state: kind_of(String),
-          subscription_name: "pger_subscription_cluster1",
-          table_name: "sellers",
-          table_schema: "pger_test",
-        },
-      )
-    end
-  end
+  #   it "successfully" do
+  #     ENV["TARGET_DB_URL"] = target_connection_url
+  #     expect(described_class.replication_stats("cluster1")).to include(
+  #       {
+  #         replication_state: kind_of(String),
+  #         subscription_name: "pger_subscription_cluster1",
+  #         table_name: "items",
+  #         table_schema: "pger_test",
+  #       },
+  #       {
+  #         replication_state: kind_of(String),
+  #         subscription_name: "pger_subscription_cluster1",
+  #         table_name: "sellers",
+  #         table_schema: "pger_test",
+  #       },
+  #     )
+  #   end
+  # end
 
-  describe ".replication_stats_count_by_state" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".replication_stats_count_by_state" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      ENV["TARGET_DB_URL"] = target_connection_url
-      expect(
-        described_class.replication_stats_count_by_state(
-          described_class.replication_stats("cluster1"),
-        ),
-      ).to be_a(Hash)
-    end
-  end
+  #   it "successfully" do
+  #     ENV["TARGET_DB_URL"] = target_connection_url
+  #     expect(
+  #       described_class.replication_stats_count_by_state(
+  #         described_class.replication_stats("cluster1"),
+  #       ),
+  #     ).to be_a(Hash)
+  #   end
+  # end
 
-  describe ".message_lsn_receipts" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".message_lsn_receipts" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      ENV["TARGET_DB_URL"] = target_connection_url
-      expect(described_class.message_lsn_receipts("cluster1").first.keys).to eq(
-        %i[
-          received_lsn
-          last_msg_send_time
-          last_msg_receipt_time
-          latest_end_lsn
-          latest_end_time
-        ],
-      )
-    end
-  end
+  #   it "successfully" do
+  #     ENV["TARGET_DB_URL"] = target_connection_url
+  #     expect(described_class.message_lsn_receipts("cluster1").first.keys).to eq(
+  #       %i[
+  #         received_lsn
+  #         last_msg_send_time
+  #         last_msg_receipt_time
+  #         latest_end_lsn
+  #         latest_end_time
+  #       ],
+  #     )
+  #   end
+  # end
 
-  describe ".object" do
-    before do
-      setup_tables
-      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  # describe ".object" do
+  #   before do
+  #     setup_tables
+  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-      PgEasyReplicate::Orchestrate.start_sync(
-        { group_name: "cluster1", schema_name: test_schema },
-      )
-    end
+  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+  #     PgEasyReplicate::Orchestrate.start_sync(
+  #       { group_name: "cluster1", schema_name: test_schema },
+  #     )
+  #   end
 
-    after do
-      PgEasyReplicate::Orchestrate.stop_sync(
-        group_name: "cluster1",
-        source_conn_string: connection_url,
-        target_conn_string: target_connection_url,
-      )
-      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-      teardown_tables
-    end
+  #   after do
+  #     PgEasyReplicate::Orchestrate.stop_sync(
+  #       group_name: "cluster1",
+  #       source_conn_string: connection_url,
+  #       target_conn_string: target_connection_url,
+  #     )
+  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+  #     teardown_tables
+  #   end
 
-    it "successfully" do
-      ENV["TARGET_DB_URL"] = target_connection_url
-      expect(described_class.object("cluster1").keys).to eq(
-        %i[
-          lag_stats
-          replication_slots
-          replication_stats
-          replication_stats_count_by_state
-          message_lsn_receipts
-          sync_started_at
-          sync_failed_at
-          switchover_completed_at
-        ],
-      )
-    end
-  end
+  #   it "successfully" do
+  #     ENV["TARGET_DB_URL"] = target_connection_url
+  #     expect(described_class.object("cluster1").keys).to eq(
+  #       %i[
+  #         lag_stats
+  #         replication_slots
+  #         replication_stats
+  #         replication_stats_count_by_state
+  #         message_lsn_receipts
+  #         sync_started_at
+  #         sync_failed_at
+  #         switchover_completed_at
+  #       ],
+  #     )
+  #   end
+  # end
 
   describe ".notify" do
     before do
@@ -244,7 +244,7 @@ RSpec.describe(PgEasyReplicate::Stats) do
       }
       allow(described_class).to receive(:object).with("cluster1").and_return(@mocked_stats)
 
-      # mocks the http request
+      # # mocks the http request
       http_double = double('http', request: double('response', code: '200', message: 'OK'))
       allow(Net::HTTP).to receive(:new).and_return(http_double)
       allow(http_double).to receive(:use_ssl=)
@@ -253,15 +253,23 @@ RSpec.describe(PgEasyReplicate::Stats) do
     end
 
     it "logs notification success and indicates switchover completion" do
-      expect { described_class.notify("cluster1", "https://example.com/webhook", 1, 5) }.to output(/Notification sent: 200 OK/).to_stdout
-      expect { described_class.notify("cluster1", "https://example.com/webhook", 1, 5) }.to output(/Switchover completed at/).to_stdout
+      thread = Thread.new do
+        expect { described_class.notify("cluster1", "https://example.com/webhook", 1, 5) }
+        .to output(/Notification sent: 200 OK/).to_stdout
+      end
+
+      sleep(0.1)
+      thread.kill # Break out of the loop so the test doesnt hang
+
+      expect { thread.join }.not_to raise_error
     end
   
     it "retries on failure" do
       allow(Net::HTTP).to receive(:new).and_raise(StandardError.new("network error"))
   
-      expect { described_class.notify("cluster1", "https://example.com/webhook", 1, 5) }
-        .to output(/An error occurred: network error/).to_stdout
+      expect {
+        described_class.notify("cluster1", "https://example.com/webhook", 1, 1)
+      }.to raise_error(StandardError, /Notify failed with: network error/)
     end
   end
 end

--- a/spec/pg_easy_replicate/stats_spec.rb
+++ b/spec/pg_easy_replicate/stats_spec.rb
@@ -1,234 +1,234 @@
 # frozen_string_literal: true
 
 RSpec.describe(PgEasyReplicate::Stats) do
-  # describe ".lag_stats" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".lag_stats" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     result = nil
-  #     count = 0
-  #     # Wait for sync stats to be up
-  #     loop do
-  #       count += 1
-  #       break if count > 5
-  #       sleep 1
-  #       result = described_class.lag_stats("cluster1").first
-  #     end
+    it "successfully" do
+      result = nil
+      count = 0
+      # Wait for sync stats to be up
+      loop do
+        count += 1
+        break if count > 5
+        sleep 1
+        result = described_class.lag_stats("cluster1").first
+      end
 
-  #     expect(result).to include(
-  #       application_name: "pger_subscription_cluster1",
-  #       client_addr: kind_of(String),
-  #       flush_lag: kind_of(BigDecimal),
-  #       pid: kind_of(Integer),
-  #       replay_lag: kind_of(BigDecimal),
-  #       state: kind_of(String),
-  #       sync_state: kind_of(String),
-  #       user_name: "james-bond",
-  #       write_lag: kind_of(BigDecimal),
-  #     )
-  #   end
-  # end
+      expect(result).to include(
+        application_name: "pger_subscription_cluster1",
+        client_addr: kind_of(String),
+        flush_lag: kind_of(BigDecimal),
+        pid: kind_of(Integer),
+        replay_lag: kind_of(BigDecimal),
+        state: kind_of(String),
+        sync_state: kind_of(String),
+        user_name: "james-bond",
+        write_lag: kind_of(BigDecimal),
+      )
+    end
+  end
 
-  # describe ".pg_replication_slots" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".pg_replication_slots" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     result = nil
-  #     count = 0
-  #     # Wait for sync stats to be up
-  #     loop do
-  #       count += 1
-  #       break if count > 5
-  #       sleep 1
-  #       result = described_class.pg_replication_slots("cluster1").first
-  #     end
+    it "successfully" do
+      result = nil
+      count = 0
+      # Wait for sync stats to be up
+      loop do
+        count += 1
+        break if count > 5
+        sleep 1
+        result = described_class.pg_replication_slots("cluster1").first
+      end
 
-  #     expect(result).to include(
-  #       slot_name: "pger_subscription_cluster1",
-  #       slot_type: "logical",
-  #     )
-  #   end
-  # end
+      expect(result).to include(
+        slot_name: "pger_subscription_cluster1",
+        slot_type: "logical",
+      )
+    end
+  end
 
-  # describe ".replication_stats" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".replication_stats" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     ENV["TARGET_DB_URL"] = target_connection_url
-  #     expect(described_class.replication_stats("cluster1")).to include(
-  #       {
-  #         replication_state: kind_of(String),
-  #         subscription_name: "pger_subscription_cluster1",
-  #         table_name: "items",
-  #         table_schema: "pger_test",
-  #       },
-  #       {
-  #         replication_state: kind_of(String),
-  #         subscription_name: "pger_subscription_cluster1",
-  #         table_name: "sellers",
-  #         table_schema: "pger_test",
-  #       },
-  #     )
-  #   end
-  # end
+    it "successfully" do
+      ENV["TARGET_DB_URL"] = target_connection_url
+      expect(described_class.replication_stats("cluster1")).to include(
+        {
+          replication_state: kind_of(String),
+          subscription_name: "pger_subscription_cluster1",
+          table_name: "items",
+          table_schema: "pger_test",
+        },
+        {
+          replication_state: kind_of(String),
+          subscription_name: "pger_subscription_cluster1",
+          table_name: "sellers",
+          table_schema: "pger_test",
+        },
+      )
+    end
+  end
 
-  # describe ".replication_stats_count_by_state" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".replication_stats_count_by_state" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     ENV["TARGET_DB_URL"] = target_connection_url
-  #     expect(
-  #       described_class.replication_stats_count_by_state(
-  #         described_class.replication_stats("cluster1"),
-  #       ),
-  #     ).to be_a(Hash)
-  #   end
-  # end
+    it "successfully" do
+      ENV["TARGET_DB_URL"] = target_connection_url
+      expect(
+        described_class.replication_stats_count_by_state(
+          described_class.replication_stats("cluster1"),
+        ),
+      ).to be_a(Hash)
+    end
+  end
 
-  # describe ".message_lsn_receipts" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".message_lsn_receipts" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     ENV["TARGET_DB_URL"] = target_connection_url
-  #     expect(described_class.message_lsn_receipts("cluster1").first.keys).to eq(
-  #       %i[
-  #         received_lsn
-  #         last_msg_send_time
-  #         last_msg_receipt_time
-  #         latest_end_lsn
-  #         latest_end_time
-  #       ],
-  #     )
-  #   end
-  # end
+    it "successfully" do
+      ENV["TARGET_DB_URL"] = target_connection_url
+      expect(described_class.message_lsn_receipts("cluster1").first.keys).to eq(
+        %i[
+          received_lsn
+          last_msg_send_time
+          last_msg_receipt_time
+          latest_end_lsn
+          latest_end_time
+        ],
+      )
+    end
+  end
 
-  # describe ".object" do
-  #   before do
-  #     setup_tables
-  #     PgEasyReplicate.bootstrap({ group_name: "cluster1" })
+  describe ".object" do
+    before do
+      setup_tables
+      PgEasyReplicate.bootstrap({ group_name: "cluster1" })
 
-  #     ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
-  #     PgEasyReplicate::Orchestrate.start_sync(
-  #       { group_name: "cluster1", schema_name: test_schema },
-  #     )
-  #   end
+      ENV["SECONDARY_SOURCE_DB_URL"] = docker_compose_source_connection_url
+      PgEasyReplicate::Orchestrate.start_sync(
+        { group_name: "cluster1", schema_name: test_schema },
+      )
+    end
 
-  #   after do
-  #     PgEasyReplicate::Orchestrate.stop_sync(
-  #       group_name: "cluster1",
-  #       source_conn_string: connection_url,
-  #       target_conn_string: target_connection_url,
-  #     )
-  #     PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
-  #     teardown_tables
-  #   end
+    after do
+      PgEasyReplicate::Orchestrate.stop_sync(
+        group_name: "cluster1",
+        source_conn_string: connection_url,
+        target_conn_string: target_connection_url,
+      )
+      PgEasyReplicate.cleanup({ everything: true, group_name: "cluster1" })
+      teardown_tables
+    end
 
-  #   it "successfully" do
-  #     ENV["TARGET_DB_URL"] = target_connection_url
-  #     expect(described_class.object("cluster1").keys).to eq(
-  #       %i[
-  #         lag_stats
-  #         replication_slots
-  #         replication_stats
-  #         replication_stats_count_by_state
-  #         message_lsn_receipts
-  #         sync_started_at
-  #         sync_failed_at
-  #         switchover_completed_at
-  #       ],
-  #     )
-  #   end
-  # end
+    it "successfully" do
+      ENV["TARGET_DB_URL"] = target_connection_url
+      expect(described_class.object("cluster1").keys).to eq(
+        %i[
+          lag_stats
+          replication_slots
+          replication_stats
+          replication_stats_count_by_state
+          message_lsn_receipts
+          sync_started_at
+          sync_failed_at
+          switchover_completed_at
+        ],
+      )
+    end
+  end
 
   describe ".notify" do
     before do


### PR DESCRIPTION
PR adds the following:

- cli integration using `--notify` (includes support for configuring` --group_name, --url, --frequency, --timeout`)
- Logic to handle pushing stats notifications to a https endpoint on a loop using timeout and frequency 
- Test coverage for notify
- README updates on how to use the new command