### PR TITLE
added correct user to stop_sync drop of subscription

### DIFF
--- a/lib/pg_easy_replicate/orchestrate.rb
+++ b/lib/pg_easy_replicate/orchestrate.rb
@@ -166,6 +166,7 @@ module PgEasyReplicate
         Query.run(
           query: "DROP SUBSCRIPTION IF EXISTS #{subscription_name(group_name)}",
           connection_url: target_conn_string,
+          user: db_user(target_conn_string),
           transaction: false,
         )
       rescue => e


### PR DESCRIPTION
During testing of `stop_sync` I encountered the following error when it tries to drop the subscription:

`PG::InsufficientPrivilege: ERROR: must be owner: pg_subscription_zdt_migration_test`

I noticed that we specify the user to create the subscription but it was not assuming this user to drop it afterwards causing the above error.