### PR TITLE
Ensure default for recreate_indices_post_copy is always false (match cli default)

### DIFF
--- a/lib/pg_easy_replicate/group.rb
+++ b/lib/pg_easy_replicate/group.rb
@@ -20,7 +20,7 @@ module PgEasyReplicate
           column(:updated_at, Time, default: Sequel::CURRENT_TIMESTAMP)
           column(:started_at, Time)
           column(:failed_at, Time)
-          column(:recreate_indices_post_copy, TrueClass, default: true)
+          column(:recreate_indices_post_copy, TrueClass, default: false)
           column(:switchover_completed_at, Time)
         end
       ensure
@@ -44,6 +44,7 @@ module PgEasyReplicate
           schema_name: options[:schema_name],
           started_at: options[:started_at],
           failed_at: options[:failed_at],
+          recreate_indices_post_copy: options[:recreate_indices_post_copy],
         )
       rescue => e
         abort_with("Adding group entry failed: #{e.message}")

--- a/spec/pg_easy_replicate/group_spec.rb
+++ b/spec/pg_easy_replicate/group_spec.rb
@@ -118,6 +118,19 @@ RSpec.describe(PgEasyReplicate::Group) do
           schema: PgEasyReplicate.internal_schema_name,
         )
       expect(r.first[:name]).to eq("test")
+      expect(r.first[:recreate_indices_post_copy]).to be_nil
+    end
+
+    it "adds a row with recreate_indices_post_copy" do
+      described_class.create({ name: "test", recreate_indices_post_copy: true })
+
+      r =
+        PgEasyReplicate::Query.run(
+          query: "select * from groups",
+          connection_url: connection_url,
+          schema: PgEasyReplicate.internal_schema_name,
+        )
+      expect(r.first[:recreate_indices_post_copy]).to be(true)
     end
 
     it "adds a row with table names and schema" do

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -795,7 +795,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       ENV["TARGET_DB_URL"] = target_connection_url
     end
 
-    it "succesfully raises lack of super user error" do
+    it "successfully raises lack of super user error" do
       conn1 =
         PgEasyReplicate::Query.connect(
           connection_url: connection_url("james-bond_role_regular"),
@@ -824,7 +824,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
           schema_name: test_schema,
           recreate_indices_post_copy: false,
         )
-      end.to raise_error(/Starting sync failed: PG::InsufficientPrivilege/)
+      end.to raise_error(/PG::InsufficientPrivilege/)
 
       # expect(PgEasyReplicate::Group.find("cluster1")).to include(
       #   switchover_completed_at: nil,

--- a/spec/pg_easy_replicate/orchestrate_spec.rb
+++ b/spec/pg_easy_replicate/orchestrate_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       expect(pg_publications(connection_url: connection_url)).to eq(
@@ -304,7 +304,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         updated_at: kind_of(Time),
         failed_at: nil,
         table_names: "items,sellers",
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
     end
 
@@ -318,7 +318,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         described_class.start_sync(
           group_name: "cluster1",
           schema_name: test_schema,
-          recreate_indices_post_copy: true,
+          recreate_indices_post_copy: false,
         )
       end.to raise_error(RuntimeError, "Starting sync failed: boo")
 
@@ -339,7 +339,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       PgEasyReplicate::Orchestrate.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
     end
 
@@ -426,7 +426,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       expect(PgEasyReplicate::Group.find("cluster1")).to include(
@@ -439,7 +439,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         updated_at: kind_of(Time),
         failed_at: nil,
         table_names: "items,sellers",
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       conn1[:items].insert(name: "Foo2")
@@ -559,7 +559,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       conn1[:items].insert(name: "Foo2")
@@ -609,7 +609,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         group_name: "cluster1",
         schema_name: test_schema,
         exclude_tables: ["sellers"],
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       expect(PgEasyReplicate::Group.find("cluster1")).to include(
@@ -622,7 +622,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         updated_at: kind_of(Time),
         failed_at: nil,
         table_names: "items",
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       conn1[:items].insert(name: "Foo2")
@@ -726,7 +726,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       allow(described_class).to receive(:drop_subscription).and_raise(
@@ -822,7 +822,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
         described_class.start_sync(
           group_name: "cluster1",
           schema_name: test_schema,
-          recreate_indices_post_copy: true,
+          recreate_indices_post_copy: false,
         )
       end.to raise_error(/Starting sync failed: PG::InsufficientPrivilege/)
 
@@ -904,7 +904,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
         exclude_tables: ["items"],
       )
 
@@ -931,7 +931,7 @@ RSpec.describe(PgEasyReplicate::Orchestrate) do
       described_class.start_sync(
         group_name: "cluster1",
         schema_name: test_schema,
-        recreate_indices_post_copy: true,
+        recreate_indices_post_copy: false,
       )
 
       expect(PgEasyReplicate::Group.find("cluster1")).to include(


### PR DESCRIPTION


This way we don't attempt to recreate indices post switchover (no-op anyways)